### PR TITLE
feat: persist DMCMM state

### DIFF
--- a/DecompositionMonteCarloMM.mqh
+++ b/DecompositionMonteCarloMM.mqh
@@ -108,6 +108,27 @@ public:
       return (double)u * gm();                // 基本ベット額=1
    }
 
+   string Serialize() const{
+      string seqStr="";
+      for(int i=0;i<ArraySize(seq);i++){
+         if(i) seqStr+=",";
+         seqStr+=IntegerToString(seq[i]);
+      }
+      return(IntegerToString(stock)+"|"+IntegerToString(streak)+"|"+seqStr);
+   }
+
+   bool Deserialize(const string data){
+      string parts[]; int cnt=StringSplit(data,'|',parts);
+      if(cnt!=3) return(false);
+      stock=(int)StringToInteger(parts[0]);
+      streak=(int)StringToInteger(parts[1]);
+      string seqParts[]; int n=StringSplit(parts[2],',',seqParts);
+      if(n<2) return(false);
+      ArrayResize(seq,n);
+      for(int i=0;i<n;i++) seq[i]=(int)StringToInteger(seqParts[i]);
+      return(true);
+   }
+
    /* デバッグ用 */
    string Seq(){string s="";for(int i=0;i<ArraySize(seq);i++){if(i)s+=",";s+=IntegerToString(seq[i]);}return s;}
    int    Stock(){ return stock; }


### PR DESCRIPTION
## Summary
- serialize/deserialize DMCMM internal state
- load and save state for each system on init/deinit with error logging

## Testing
- `npm test` (fails: package.json missing)
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_688f7c6bc2088327ad86f80a3b0036fb