### PR TITLE
CalcLotでNormalizeLot後にMaxLotを再適用

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -310,7 +310,8 @@ double CalcLot(const string system,string &seq)
       seq          = "(" + state.Seq() + ")";
       lotCandidate = BaseLot * lotFactor;
 
-      double lotActual = NormalizeLot(MathMin(lotCandidate, MaxLot));
+      double lotActual = NormalizeLot(lotCandidate);
+      lotActual        = MathMin(lotActual, MaxLot);
 
       LogRecord lr;
       lr.Time       = TimeCurrent();
@@ -338,7 +339,8 @@ double CalcLot(const string system,string &seq)
       return(lotActual);
    }
 
-   double lotActual = NormalizeLot(MathMin(lotCandidate, MaxLot));
+   double lotActual = NormalizeLot(lotCandidate);
+   lotActual        = MathMin(lotActual, MaxLot);
    return(lotActual);
 }
 


### PR DESCRIPTION
## Summary
- CalcLotで候補ロットを正規化した後、MaxLotで再クリップする処理に修正

## Testing
- `wine metaeditor64.exe /compile:experts/MoveCatcher.mq4 /log:compile.log` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_688f9286ae208327912de48512cf0f27