### PR TITLE
UpdateState の欠落状態継続処理を追加

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -395,6 +395,8 @@ SystemState UpdateState(const SystemState prev,const bool exists)
    }
    if(prev == Alive || prev == MissingRecovered)
       return(Missing);
+   if(prev == Missing)
+      return(Missing);
    return(None);
 }
 


### PR DESCRIPTION
## Summary
- UpdateState で prev が Missing のままポジションが存在しない場合に Missing を返す条件を追加し、欠落状態を保持する。

## Testing
- `pre-commit run --files experts/MoveCatcher.mq4` (InvalidConfigError: .pre-commit-config.yaml is not a file)
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_688f951330f0832795464c8f2a912962