### PR TITLE
Fix EnsureTPSL distance checks

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -516,16 +516,29 @@ void EnsureTPSL(const int ticket)
       return;
    double entry = OrderOpenPrice();
    double desiredSL, desiredTP;
+   double stopLevel   = MarketInfo(Symbol(), MODE_STOPLEVEL) * Point;
+   double freezeLevel = MarketInfo(Symbol(), MODE_FREEZELEVEL) * Point;
+   double minDist     = MathMax(stopLevel, freezeLevel);
    if(OrderType() == OP_BUY)
    {
       desiredSL = entry - PipsToPrice(GridPips);
       desiredTP = entry + PipsToPrice(GridPips);
+      if(Bid - desiredSL < minDist)
+         desiredSL = Bid - minDist;
+      if(desiredTP - Ask < minDist)
+         desiredTP = Ask + minDist;
    }
    else
    {
       desiredSL = entry + PipsToPrice(GridPips);
       desiredTP = entry - PipsToPrice(GridPips);
+      if(desiredSL - Ask < minDist)
+         desiredSL = Ask + minDist;
+      if(Bid - desiredTP < minDist)
+         desiredTP = Bid - minDist;
    }
+   desiredSL = NormalizeDouble(desiredSL, Digits);
+   desiredTP = NormalizeDouble(desiredTP, Digits);
    if(OrderStopLoss() == 0 || OrderTakeProfit() == 0)
    {
       if(!OrderModify(ticket, entry, desiredSL, desiredTP, 0, clrNONE))


### PR DESCRIPTION
## Summary
- respect broker StopLevel/FreezeLevel when setting TP/SL

## Testing
- `wine metaeditor /compile:experts/MoveCatcher.mq4` *(fails: wine32 missing / no X server)*

------
https://chatgpt.com/codex/tasks/task_e_688f964a77788327abeae662284de192