### PR TITLE
MaxLot適用後にロットを再正規化

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -312,9 +312,8 @@ double CalcLot(const string system,string &seq)
       lotFactor    = state.NextLot();
       seq          = "(" + state.Seq() + ")";
       lotCandidate = BaseLot * lotFactor;
-
+      lotCandidate = MathMin(lotCandidate, MaxLot);
       double lotActual = NormalizeLot(lotCandidate);
-      lotActual        = MathMin(lotActual, MaxLot);
 
       LogRecord lr;
       lr.Time       = TimeCurrent();
@@ -342,8 +341,8 @@ double CalcLot(const string system,string &seq)
       return(lotActual);
    }
 
+   lotCandidate = MathMin(lotCandidate, MaxLot);
    double lotActual = NormalizeLot(lotCandidate);
-   lotActual        = MathMin(lotActual, MaxLot);
    return(lotActual);
 }
 


### PR DESCRIPTION
## Summary
- CalcLotでMaxLotを適用した後にNormalizeLotを再実行し、LotStep/Min/Maxに一致させる
- 再計算したロット値をログと戻り値に反映

## Testing
- `make test` (テストターゲットなし)


------
https://chatgpt.com/codex/tasks/task_e_688fb022dd808327accb9ff0bb0abc33