### PR TITLE
Invoke DMC update after duplicate position correction

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -952,6 +952,7 @@ void CorrectDuplicatePositions()
          if(!ok)
             PrintFormat("CorrectDuplicatePositions: failed to close %d err=%d", tk, err);
       }
+      ProcessClosedTrades("A");
       DeletePendings("A", "RESET_DUP");
    }
 
@@ -1001,6 +1002,7 @@ void CorrectDuplicatePositions()
          if(!ok)
             PrintFormat("CorrectDuplicatePositions: failed to close %d err=%d", tk, err);
       }
+      ProcessClosedTrades("B");
       DeletePendings("B", "RESET_DUP");
    }
 }


### PR DESCRIPTION
## Summary
- Call `ProcessClosedTrades("A"/"B")` after closing duplicate positions to update DMCMM state
- Preserve existing logging so closure results are recorded

## Testing
- `wine metaeditor.exe /compile:experts/MoveCatcher.mq4 /log /portable` *(fails: metaeditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fb37f63388327bae24af58e59a389