### PR TITLE
Ensure TP/SL adjustments in MoveCatcher

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -547,10 +547,20 @@ void EnsureTPSL(const int ticket)
    }
    desiredSL = NormalizeDouble(desiredSL, Digits);
    desiredTP = NormalizeDouble(desiredTP, Digits);
-   if(OrderStopLoss() == 0 || OrderTakeProfit() == 0)
+   double tol = Point * 0.5;
+   bool needModify = (OrderStopLoss() == 0 || OrderTakeProfit() == 0 ||
+                      MathAbs(OrderStopLoss() - desiredSL) > tol ||
+                      MathAbs(OrderTakeProfit() - desiredTP) > tol);
+   if(needModify)
    {
       if(!OrderModify(ticket, entry, desiredSL, desiredTP, 0, clrNONE))
-         PrintFormat("EnsureTPSL: failed to set TP/SL for ticket %d err=%d", ticket, GetLastError());
+      {
+         int err = GetLastError();
+         if(err == 130 || err == 145)
+            PrintFormat("EnsureTPSL: TP/SL for ticket %d within stop/freeze level, retry next tick err=%d", ticket, err);
+         else
+            PrintFormat("EnsureTPSL: failed to set TP/SL for ticket %d err=%d", ticket, err);
+      }
    }
 }
 


### PR DESCRIPTION
## Summary
- 既存のTP/SLが期待値から乖離している場合にのみ`OrderModify`を実行し、無駄な呼び出しを防止
- StopLevelまたはFreezeLevelによる修正拒否時には再試行用のログを出力

## Testing
- `rg EnsureTPSL -n`


------
https://chatgpt.com/codex/tasks/task_e_688fc8c9081083279de72fab170b6059