### PR TITLE
Skip DMC update on reset closures

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -825,6 +825,7 @@ void RecoverAfterSL(const string system)
 //+------------------------------------------------------------------+
 void CloseAllOrders(const string reason)
 {
+   bool updateDMC = (reason != "RESET_ALIVE" && reason != "RESET_SNAP");
    RefreshRates();
    for(int i = OrdersTotal()-1; i >= 0; i--)
    {
@@ -868,7 +869,7 @@ void CloseAllOrders(const string reason)
          WriteLog(lr);
          if(!ok)
             PrintFormat("CloseAllOrders: failed to close %d err=%d", ticket, err);
-         else
+         else if(updateDMC)
             ProcessClosedTrades(sysTmp);
       }
       else if(type == OP_BUYLIMIT || type == OP_SELLLIMIT ||


### PR DESCRIPTION
## Summary
- CloseAllOrdersでRESET_ALIVE/RESET_SNAP時はProcessClosedTradesを実行しないようフラグを導入

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fce5314b08327a3accd7bda025c2a