### PR TITLE
Ensure CalcLot respects MaxLot after normalization

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -315,6 +315,8 @@ double CalcLot(const string system,string &seq,double &lotFactor)
       lotCandidate = BaseLot * lotFactor;
       lotCandidate = MathMin(lotCandidate, MaxLot);
       double lotActual = NormalizeLot(lotCandidate);
+      if(lotActual > MaxLot)
+         lotActual = NormalizeLot(MaxLot);
 
       LogRecord lr;
       lr.Time       = TimeCurrent();
@@ -344,6 +346,8 @@ double CalcLot(const string system,string &seq,double &lotFactor)
 
    lotCandidate = MathMin(lotCandidate, MaxLot);
    double lotActual = NormalizeLot(lotCandidate);
+   if(lotActual > MaxLot)
+      lotActual = NormalizeLot(MaxLot);
    return(lotActual);
 }
 


### PR DESCRIPTION
## Summary
- ensure CalcLot caps normalized lot sizes to MaxLot

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_688fd01e02ec8327bd8cd27d0d314ba3