### PR TITLE
影指値設置ログの理由をREFILLへ修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ README.md                                  ← 本ドキュメント
 各発注・約定・取消・初期化で以下を記録（ファイル or `Print`）：
 
 * `Time, Symbol, System{A|B}, Reason{INIT,REFILL,TP,SL,RESET_ALIVE,RESET_SNAP,LOT_RESET}`
+  * `REFILL` = 補充指値・影指値の設置
 * `Spread(pips), Dist(pips), GridPips, s, EpsilonPips`
 * `lotFactor, BaseLot, MaxLot, actualLot`
 * `seqStr, CommentTag, Magic`

--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -610,7 +610,8 @@ void EnsureShadowOrder(const int ticket,const string system)
    lr.Time       = TimeCurrent();
    lr.Symbol     = Symbol();
    lr.System     = system;
-   lr.Reason     = "TP";
+   // REFILL: 影指値（TP反転用の指値）を設置
+   lr.Reason     = "REFILL";
    lr.Spread     = PriceToPips(Ask - Bid);
    lr.Dist       = GridPips;
    lr.GridPips   = GridPips;


### PR DESCRIPTION
## 概要
- EnsureShadowOrderで出力するログの理由をTPからREFILLへ変更
- READMEにREFILL理由の説明を追加

## テスト
- `make test`（ターゲットが存在しないため失敗）

------
https://chatgpt.com/codex/tasks/task_e_688fd14040a48327b510424e18c45e0f