### PR TITLE
fix: process entire trade history in ProcessClosedTrades

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -458,7 +458,7 @@ void ProcessClosedTrades(const string system)
          continue;
       datetime ct = OrderCloseTime();
       if(ct <= lastTime)
-         break;
+         continue;
       int idx = ArraySize(tickets);
       ArrayResize(tickets, idx + 1);
       ArrayResize(times, idx + 1);
@@ -474,12 +474,14 @@ void ProcessClosedTrades(const string system)
       if(system == "A")
       {
          stateA.OnTrade(win);
-         lastCloseTimeA = times[i];
+         if(times[i] > lastCloseTimeA)
+            lastCloseTimeA = times[i];
       }
       else
       {
          stateB.OnTrade(win);
-         lastCloseTimeB = times[i];
+         if(times[i] > lastCloseTimeB)
+            lastCloseTimeB = times[i];
       }
    }
 }


### PR DESCRIPTION
## Summary
- scan the entire order history for closed trades instead of stopping at first older record
- update lastCloseTime tracking to use the latest timestamp found

## Testing
- `wine metaeditor.exe /compile experts/MoveCatcher.mq4` *(fails: wine32 is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688fd29eb8d88327848c7960280efe5a