### PR TITLE
OrderSend 前に影指値価格を正規化

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -589,6 +589,7 @@ void EnsureShadowOrder(const int ticket,const string system)
       return;
    double price = isBuy ? entry + PipsToPrice(GridPips)
                         : entry - PipsToPrice(GridPips);
+   price = NormalizeDouble(price, Digits);
    int type = isBuy ? OP_SELLLIMIT : OP_BUYLIMIT;
    string comment = MakeComment(system, seq);
 


### PR DESCRIPTION
## Summary
- EnsureShadowOrder 内で価格計算後に NormalizeDouble を追加し、影指値の発注価格を桁数に合わせて正規化

## Testing
- `make test` (ターゲット未定義)


------
https://chatgpt.com/codex/tasks/task_e_688fd56660a48327b49e0897fb40313f