### PR TITLE
fix: RecoverAfterSL の OrderModify 再試行とログ改善

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -895,15 +895,30 @@ void RecoverAfterSL(const string system)
    }
    desiredSL = NormalizeDouble(desiredSL, Digits);
    desiredTP = NormalizeDouble(desiredTP, Digits);
-   if(!OrderModify(ticket, entry, desiredSL, desiredTP, 0, clrNONE))
-   {
-      int err = GetLastError();
-      PrintFormat("RecoverAfterSL: failed to adjust TP/SL for %s ticket %d err=%d", system, ticket, err);
-   }
    lr.EntryPrice = entry;
    lr.SL         = desiredSL;
    lr.TP         = desiredTP;
-   WriteLog(lr);
+   int err = 0;
+   if(!OrderModify(ticket, entry, desiredSL, desiredTP, 0, clrNONE))
+   {
+      err = GetLastError();
+      lr.ErrorCode = err;
+      WriteLog(lr);
+      PrintFormat("RecoverAfterSL: failed to adjust TP/SL for %s ticket %d err=%d", system, ticket, err);
+      if(system == "A")
+         retryTicketA = ticket;
+      else
+         retryTicketB = ticket;
+   }
+   else
+   {
+      lr.ErrorCode = 0;
+      WriteLog(lr);
+      if(system == "A")
+         retryTicketA = -1;
+      else
+         retryTicketB = -1;
+   }
 
    EnsureShadowOrder(ticket, system);
 


### PR DESCRIPTION
## Summary
- SL復帰時の OrderModify 失敗で取得したエラーコードを LogRecord に格納
- 失敗時も WriteLog が正しいエラーコードを含むよう修正
- OrderModify 失敗時に該当システムの retryTicket を設定し、次ティックで再設定を試行

## Testing
- `make test` (No rule to make target 'test')


------
https://chatgpt.com/codex/tasks/task_e_688fda0309088327b0a553b6044ba461