### PR TITLE
Ensure lot normalization respects MaxLot

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -153,12 +153,28 @@ double NormalizeLot(const double lotCandidate)
 
    double lot = lotCandidate;
    if(lotStep > 0)
-      lot = MathRound(lot / lotStep) * lotStep;
+      lot = MathFloor(lot / lotStep) * lotStep;
+
+   if(lot > MaxLot)
+   {
+      if(lotStep > 0)
+         lot = MathFloor(MaxLot / lotStep) * lotStep;
+      else
+         lot = MaxLot;
+   }
 
    if(lot < minLot)
       lot = minLot;
    if(lot > maxLot)
       lot = maxLot;
+
+   if(lot > MaxLot)
+   {
+      if(lotStep > 0)
+         lot = MathFloor(MaxLot / lotStep) * lotStep;
+      else
+         lot = MaxLot;
+   }
 
    return(lot);
 }


### PR DESCRIPTION
## Summary
- use floor rounding for NormalizeLot to align with lotStep
- clip rounded value to MaxLot if exceeded

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_688fe163239c8327bfb1368af61e6eb4