### PR TITLE
ProcessClosedTrades における TP/SL 判定の修正

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -505,13 +505,18 @@ void ProcessClosedTrades(const string system)
       string sysTmp, seq;
       if(!ParseComment(OrderComment(), sysTmp, seq))
          seq = "";
-      bool isTP = (type == OP_BUY) ? (OrderClosePrice() >= OrderOpenPrice())
-                                   : (OrderClosePrice() <= OrderOpenPrice());
+      double closePrice = OrderClosePrice();
+      double tol        = Point * 0.5;
+      bool isTP = (MathAbs(closePrice - OrderTakeProfit()) <= tol);
+      bool isSL = (MathAbs(closePrice - OrderStopLoss())  <= tol);
+      string reason = isTP ? "TP" : "SL";
+      if(!isTP && !isSL)
+         reason = (profit >= 0) ? "TP" : "SL";
       LogRecord lr;
       lr.Time       = times[i];
       lr.Symbol     = Symbol();
       lr.System     = system;
-      lr.Reason     = isTP ? "TP" : "SL";
+      lr.Reason     = reason;
       lr.Spread     = PriceToPips(Ask - Bid);
       lr.Dist       = 0;
       lr.GridPips   = GridPips;


### PR DESCRIPTION
## Summary
- OrderClosePrice と TP/SL の一致を比較して決済理由を判定

## Testing
- `make test` *(no rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_688fe94caaec8327956a0ca0cd15ec05