### PR TITLE
refactor: simplify MakeComment and remove unused variable

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -373,9 +373,7 @@ double CalcLot(const string system,string &seq,double &lotFactor)
 //+------------------------------------------------------------------+
 string MakeComment(const string system,const string seq)
 {
-   string comment;
-   StringConcatenate(comment,"MoveCatcher_",system,"_",seq);
-   return(comment);
+   return StringFormat("MoveCatcher_%s_%s", system, seq);
 }
 
 //+------------------------------------------------------------------+


### PR DESCRIPTION
## Summary
- simplify `MakeComment` using `StringFormat`
- remove unused temp variable in comment creation

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_6890523f9a48832789da188aced2047e