### PR TITLE
fix: refresh close times when skipping DMC update

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1036,6 +1036,8 @@ void CloseAllOrders(const string reason)
             PrintFormat("CloseAllOrders: failed to delete %d err=%d", ticket, err);
       }
    }
+   if(!updateDMC)
+      InitCloseTimes();
 }
 
 //+------------------------------------------------------------------+


### PR DESCRIPTION
## Summary
- refresh last close timestamps after closing orders during reset

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_689054b15e1083278a6cef32615bb010