### PR TITLE
Validate SnapCooldownBars parameter during initialization

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1819,6 +1819,11 @@ int OnInit()
          return(INIT_PARAMETERS_INCORRECT);
       }
    }
+   if(SnapCooldownBars < 0)
+   {
+      Print("SnapCooldownBars must be non-negative");
+      return(INIT_PARAMETERS_INCORRECT);
+   }
    if(BaseLot <= 0 || !IsStep(BaseLot,0.01))
    {
       Print("BaseLot must be positive and in 0.01 increments");


### PR DESCRIPTION
## Summary
- ensure `SnapCooldownBars` is non-negative

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_6890ac09416083279620a5cf6aeddb68