### PR TITLE
Add rate refresh at start of ProcessClosedTrades

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -456,6 +456,7 @@ void InitCloseTimes()
 //+------------------------------------------------------------------+
 void ProcessClosedTrades(const string system,const bool updateDMC)
 {
+   RefreshRates();
    datetime lastTime = (system == "A") ? lastCloseTimeA : lastCloseTimeB;
    int tickets[];
    datetime times[];


### PR DESCRIPTION
## Summary
- ensure latest price data by calling RefreshRates at the start of ProcessClosedTrades

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890b43f5fb08327babdbb6c17e4e7be