### PR TITLE
EnsureTPSLでRefreshRatesを呼び出しレート更新を保証

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -585,6 +585,7 @@ bool FindShadowPending(const string system,const double entry,const bool isBuy,
 //+------------------------------------------------------------------+
 void EnsureTPSL(const int ticket)
 {
+   RefreshRates();
    if(!OrderSelect(ticket, SELECT_BY_TICKET))
       return;
    double entry = OrderOpenPrice();


### PR DESCRIPTION
## 概要
- EnsureTPSL関数の冒頭で`RefreshRates()`を実行し、Bid/Ask参照前にレートを更新

## テスト
- `wine metaeditor.exe /compile:experts/MoveCatcher.mq4 /log:compile.log` (MetaEditor 未インストールのため失敗)


------
https://chatgpt.com/codex/tasks/task_e_6890b4f3f7ac8327a6e1e35af5d021d1