### PR TITLE
再エントリー注文で SlippagePips を適用

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1589,7 +1589,8 @@ void HandleOCODetectionFor(const string system)
 
       RefreshRates();
       double price = (type == OP_BUY) ? Ask : Bid;
-      int newTicket = OrderSend(Symbol(), type, expectedLot, price, 0, 0, 0,
+      int newTicket = OrderSend(Symbol(), type, expectedLot, price,
+                                (int)(SlippagePips * Pip() / Point), 0, 0,
                                 expectedComment, MagicNumber, 0, clrNONE);
       LogRecord lrOpen;
       lrOpen.Time       = TimeCurrent();


### PR DESCRIPTION
## Summary
- 再エントリー時の `OrderSend` に `SlippagePips` に基づくスリッページを指定

## Testing
- `make test` (テスト未定義のため失敗を確認)

------
https://chatgpt.com/codex/tasks/task_e_6890b8d016108327b5efa23222ebf934