### PR TITLE
fix: refresh rates before OrderModify

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1685,9 +1685,10 @@ void HandleOCODetectionFor(const string system)
          WriteLog(lr);
          if(!ok)
             PrintFormat("Failed to delete pending order %d err=%d", delTicket, err);
-      }
    }
+  }
 
+   RefreshRates(); // 最新の Bid/Ask を取得
    double entry = OrderOpenPrice();
    double sl, tp;
    double stopLevel   = MarketInfo(Symbol(), MODE_STOPLEVEL) * Point;


### PR DESCRIPTION
## Summary
- update Bid/Ask with RefreshRates before computing SL/TP in HandleOCODetectionFor

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_6890ba1b44bc8327af2c6f1ccfdd148a