### PR TITLE
SellLimitの距離計算をBid基準に修正

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -263,8 +263,8 @@ bool CanPlaceOrder(double &price,const bool isBuy,const double refPrice)
    double stopLevel   = MarketInfo(Symbol(), MODE_STOPLEVEL) * Point;
    double freezeLevel = MarketInfo(Symbol(), MODE_FREEZELEVEL) * Point;
 
-   // SellLimit の判定を Ask 基準に統一
-   double ref  = Ask;
+   // 注文方向に応じた基準価格を取得
+   double ref  = isBuy ? Ask : Bid;
    double dist = MathAbs(price - ref);
 
    if(dist < freezeLevel)
@@ -1207,7 +1207,7 @@ void PlaceRefillOrders(const string system,const double refPrice)
    double stopLevel   = MarketInfo(Symbol(), MODE_STOPLEVEL) * Point;
    double freezeLevel = MarketInfo(Symbol(), MODE_FREEZELEVEL) * Point;
 
-   double distSell = MathAbs(Ask - priceSell);
+   double distSell = MathAbs(Bid - priceSell);
    if(distSell < freezeLevel)
       PrintFormat("PlaceRefillOrders: SellLimit %.5f within freeze level %.1f pips, retry next tick",
                   priceSell, PriceToPips(freezeLevel));
@@ -1216,7 +1216,7 @@ void PlaceRefillOrders(const string system,const double refPrice)
       if(distSell < stopLevel)
       {
          double old = priceSell;
-         priceSell = NormalizeDouble(Ask + stopLevel, Digits);
+         priceSell = NormalizeDouble(Bid + stopLevel, Digits);
          PrintFormat("PlaceRefillOrders: SellLimit adjusted from %.5f to %.5f due to stop level %.1f pips",
                      old, priceSell, PriceToPips(stopLevel));
       }
@@ -1394,7 +1394,7 @@ void InitStrategy()
    stopLevel   = MarketInfo(Symbol(), MODE_STOPLEVEL) * Point;
    freezeLevel = MarketInfo(Symbol(), MODE_FREEZELEVEL) * Point;
 
-   double distSell = MathAbs(Ask - priceSell);
+   double distSell = MathAbs(Bid - priceSell);
    if(distSell < freezeLevel)
       PrintFormat("InitStrategy: SellLimit %.5f within freeze level %.1f pips, retry next tick",
                   priceSell, PriceToPips(freezeLevel));
@@ -1403,7 +1403,7 @@ void InitStrategy()
       if(distSell < stopLevel)
       {
          double oldS = priceSell;
-         priceSell = NormalizeDouble(Ask + stopLevel, Digits);
+         priceSell = NormalizeDouble(Bid + stopLevel, Digits);
          PrintFormat("InitStrategy: SellLimit adjusted from %.5f to %.5f due to stop level %.1f pips",
                      oldS, priceSell, PriceToPips(stopLevel));
       }


### PR DESCRIPTION
## Summary
- CanPlaceOrderで基準価格を注文方向に応じてAsk/Bidから取得するよう修正
- Refill/Init時のSellLimit距離判定とStopLevel補正をBid基準に変更

## Testing
- `npm test` (package.jsonが存在せず失敗)
- `make test` (テスト用ルール未定義)


------
https://chatgpt.com/codex/tasks/task_e_6890bd2bff8c8327b10388a40d0a3ded