### PR TITLE
NormalizeLot の丸め処理と MaxLot 判定の整理

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -153,28 +153,14 @@ double NormalizeLot(const double lotCandidate)
 
    double lot = lotCandidate;
    if(lotStep > 0)
-      lot = MathFloor(lot / lotStep) * lotStep;
-
-   if(lot > MaxLot)
-   {
-      if(lotStep > 0)
-         lot = MathFloor(MaxLot / lotStep) * lotStep;
-      else
-         lot = MaxLot;
-   }
+      lot = MathRound(lot / lotStep) * lotStep;
 
    if(lot < minLot)
       lot = minLot;
    if(lot > maxLot)
       lot = maxLot;
-
    if(lot > MaxLot)
-   {
-      if(lotStep > 0)
-         lot = MathFloor(MaxLot / lotStep) * lotStep;
-      else
-         lot = MaxLot;
-   }
+      lot = MaxLot;
 
    return(lot);
 }


### PR DESCRIPTION
## Summary
- ロット計算で MathRound を用いて LotStep に丸めるよう修正
- MaxLot/ブローカー制限によるクリップ処理を一本化し、冗長な判定を削除

## Testing
- `make test` (対象ターゲットなし)

------
https://chatgpt.com/codex/tasks/task_e_6890bed48f208327bbff90cb36bf1542