### PR TITLE
Normalize sl/tp calculations in RecoverAfterSL

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -825,8 +825,8 @@ void RecoverAfterSL(const string system)
    bool   isBuy    = (lastType == OP_BUY);
    int    slippage = UseProtectedLimit ? (int)(SlippagePips * Pip() / Point) : 0;
    double price    = isBuy ? Ask : Bid;
-   double sl       = isBuy ? price - PipsToPrice(GridPips) : price + PipsToPrice(GridPips);
-   double tp       = isBuy ? price + PipsToPrice(GridPips) : price - PipsToPrice(GridPips);
+   double sl       = NormalizeDouble(isBuy ? price - PipsToPrice(GridPips) : price + PipsToPrice(GridPips), Digits);
+   double tp       = NormalizeDouble(isBuy ? price + PipsToPrice(GridPips) : price - PipsToPrice(GridPips), Digits);
    double stopLevel   = MarketInfo(Symbol(), MODE_STOPLEVEL) * Point;
    double freezeLevel = MarketInfo(Symbol(), MODE_FREEZELEVEL) * Point;
    double minLevel    = MathMax(stopLevel, freezeLevel);


### PR DESCRIPTION
## Summary
- Apply `NormalizeDouble` to `sl` and `tp` when computing recovery orders.
- Preserve normalization after minimum distance corrections.

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6890c00b09288327a4a9bc2a2eb4d2bf