### PR TITLE
Log entry data on SL recovery success

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -871,10 +871,13 @@ void RecoverAfterSL(const string system)
    lr.CommentTag = comment;
    lr.Magic      = MagicNumber;
    lr.OrderType  = OrderTypeToStr(type);
+   lr.EntryPrice = price;
+   lr.SL         = sl;
+   lr.TP         = tp;
    lr.ErrorCode  = (ticket < 0) ? GetLastError() : 0;
+   WriteLog(lr);
    if(ticket < 0)
    {
-      WriteLog(lr);
       PrintFormat("RecoverAfterSL: failed to reopen %s err=%d", system, lr.ErrorCode);
       return;
    }


### PR DESCRIPTION
## Summary
- log reopening price, SL and TP when recovering after stop loss
- emit log record on successful reopen to avoid missing recovery events
- streamline conditional logging to prevent duplicate failure records

## Testing
- `wine metaeditor` *(fails: MetaEditor executable not found and wine32 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890c0e6ce0c83279c37d9f03ae258c6