### PR TITLE
DeletePendingsで削除前に注文情報を退避

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -754,6 +754,11 @@ void DeletePendings(const string system,const string reason)
       if(sys != system)
          continue;
       int tk = OrderTicket();
+      double lots = OrderLots();
+      double entry = OrderOpenPrice();
+      double sl    = OrderStopLoss();
+      double tp    = OrderTakeProfit();
+      string comment = OrderComment();
       int err = 0;
       bool ok = OrderDelete(tk);
       if(!ok)
@@ -770,14 +775,14 @@ void DeletePendings(const string system,const string reason)
       lr.lotFactor  = 0;
       lr.BaseLot    = BaseLot;
       lr.MaxLot     = MaxLot;
-      lr.actualLot  = OrderLots();
+      lr.actualLot  = lots;
       lr.seqStr     = seq;
-      lr.CommentTag = OrderComment();
+      lr.CommentTag = comment;
       lr.Magic      = MagicNumber;
       lr.OrderType  = OrderTypeToStr(type);
-      lr.EntryPrice = OrderOpenPrice();
-      lr.SL         = OrderStopLoss();
-      lr.TP         = OrderTakeProfit();
+      lr.EntryPrice = entry;
+      lr.SL         = sl;
+      lr.TP         = tp;
       lr.ErrorCode  = err;
       WriteLog(lr);
       if(!ok)


### PR DESCRIPTION
## Summary
- キャッシュした注文情報を用いてDeletePendingsでのログを改善

## Testing
- `wine metaeditor.exe /compile:MoveCatcher.mq4` (fails: missing wine32/metaeditor)

------
https://chatgpt.com/codex/tasks/task_e_6890c2b2dfb0832783259163ba683291