### PR TITLE
slippage 計算の条件整理

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -887,7 +887,8 @@ void DeletePendings(const string system,const string reason)
 }
 
 //+------------------------------------------------------------------+
-//| Re-enter position after SL according to UseProtectedLimit         |
+//| Re-enter position after SL; UseProtectedLimit selects method while |
+//| slippage always uses user input                                    |
 //+------------------------------------------------------------------+
 void RecoverAfterSL(const string system)
 {
@@ -924,7 +925,7 @@ void RecoverAfterSL(const string system)
       return;
 
    bool   isBuy    = (lastType == OP_BUY);
-   int    slippage = UseProtectedLimit ? (int)(SlippagePips * Pip() / Point) : 0;
+   int    slippage = (int)(SlippagePips * Pip() / Point); // respect user-defined slippage
    double price    = isBuy ? Ask : Bid;
    double sl       = NormalizeDouble(isBuy ? price - PipsToPrice(GridPips) : price + PipsToPrice(GridPips), Digits);
    double tp       = NormalizeDouble(isBuy ? price + PipsToPrice(GridPips) : price - PipsToPrice(GridPips), Digits);


### PR DESCRIPTION
## Summary
- RecoverAfterSL で常に SlippagePips を変換して使用し、UseProtectedLimit に依存しないよう整理

## Testing
- `make test` (No rule to make target 'test')


------
https://chatgpt.com/codex/tasks/task_e_6890dbe1aa488327a126a3fc1783b38a