### PR TITLE
Honor UseProtectedLimit for slippage on market orders

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -925,7 +925,7 @@ void RecoverAfterSL(const string system)
       return;
 
    bool   isBuy    = (lastType == OP_BUY);
-   int    slippage = (int)(SlippagePips * Pip() / Point); // respect user-defined slippage
+   int    slippage = UseProtectedLimit ? (int)(SlippagePips * Pip() / Point) : 0; // respect user-defined slippage
    double price    = isBuy ? Ask : Bid;
    double sl       = NormalizeDouble(isBuy ? price - PipsToPrice(GridPips) : price + PipsToPrice(GridPips), Digits);
    double tp       = NormalizeDouble(isBuy ? price + PipsToPrice(GridPips) : price - PipsToPrice(GridPips), Digits);
@@ -2240,8 +2240,9 @@ void HandleOCODetectionFor(const string system)
             retryTicketB = -1;
          return;
       }
+      int    slippage = UseProtectedLimit ? (int)(SlippagePips * Pip() / Point) : 0;
       int newTicket = OrderSend(Symbol(), type, expectedLot, price,
-                                (int)(SlippagePips * Pip() / Point), 0, 0,
+                                slippage, 0, 0,
                                 expectedComment, MagicNumber, 0, clrNONE);
       LogRecord lrOpen;
       lrOpen.Time       = TimeCurrent();


### PR DESCRIPTION
## Summary
- Apply slippage only when UseProtectedLimit is enabled in RecoverAfterSL
- Apply slippage only when UseProtectedLimit is enabled in HandleOCODetectionFor

## Testing
- `wine metaeditor64.exe /compile:experts/MoveCatcher.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890e3cd95308327826c7d3ae8e246cb