### PR TITLE
StopLevel補正後にFreezeLevelを再判定

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -292,6 +292,15 @@ bool CanPlaceOrder(double &price,const bool isBuy,const double refPrice)
       price = NormalizeDouble(price, Digits);
       PrintFormat("CanPlaceOrder: price adjusted from %.5f to %.5f due to stop level %.1f pips",
                   oldPrice, price, PriceToPips(stopLevel));
+
+      // StopLevel 補正後に距離を再計算し、FreezeLevel を再チェック
+      dist = MathAbs(price - ref);
+      if(dist < freezeLevel)
+      {
+         PrintFormat("CanPlaceOrder: price %.5f within freeze level %.1f pips after stop adjustment, retry next tick",
+                     price, PriceToPips(freezeLevel));
+         return(false);
+      }
    }
 
    double spread = PriceToPips(Ask - Bid);


### PR DESCRIPTION
## Summary
- StopLevel補正後に距離を再計算し、FreezeLevel違反なら発注を中止

## Testing
- `make test` *(No rule to make target 'test'. Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_6890e55f2eac8327917f10e6aec94008