### PR TITLE
fix: avoid duplicate OCO detection

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2532,6 +2532,7 @@ int OnInit()
 
 void OnTick()
 {
+   // OCO detection should run once per tick at the beginning
    HandleOCODetection();
    CorrectDuplicatePositions();
 
@@ -2698,9 +2699,6 @@ void OnTick()
       RecoverAfterSL("A");
    if(state_B == Missing)
       RecoverAfterSL("B");
-
-   if(retryTicketA != -1 || retryTicketB != -1)
-      HandleOCODetection();
 }
 
 void OnDeinit(const int reason)


### PR DESCRIPTION
## Summary
- ensure `HandleOCODetection` is invoked only once per tick

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6890e6de6fc483279789c3539f341711