### PR TITLE
UseProtectedLimitの有無に関わらずSlippagePipsを適用

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -934,7 +934,7 @@ void RecoverAfterSL(const string system)
       return;
 
    bool   isBuy    = (lastType == OP_BUY);
-   int    slippage = UseProtectedLimit ? (int)(SlippagePips * Pip() / Point) : 0; // respect user-defined slippage
+   int    slippage = (int)(SlippagePips * Pip() / Point); // respect user-defined slippage
    double price    = isBuy ? Ask : Bid;
    double sl       = NormalizeDouble(isBuy ? price - PipsToPrice(GridPips) : price + PipsToPrice(GridPips), Digits);
    double tp       = NormalizeDouble(isBuy ? price + PipsToPrice(GridPips) : price - PipsToPrice(GridPips), Digits);
@@ -2249,7 +2249,7 @@ void HandleOCODetectionFor(const string system)
             retryTicketB = -1;
          return;
       }
-      int    slippage = UseProtectedLimit ? (int)(SlippagePips * Pip() / Point) : 0;
+      int    slippage = (int)(SlippagePips * Pip() / Point);
       int newTicket = OrderSend(Symbol(), type, expectedLot, price,
                                 slippage, 0, 0,
                                 expectedComment, MagicNumber, 0, clrNONE);


### PR DESCRIPTION
## 概要
- SL復帰時の成行注文で常に`SlippagePips`を使用
- OCO再補充でも`SlippagePips`を共通利用

## テスト
- `UseProtectedLimit`が`true/false`いずれの場合も同じslippage値になることをPythonで確認


------
https://chatgpt.com/codex/tasks/task_e_68910283139c8327ab5800efdf2f4332