### PR TITLE
Handle manual close without DMCMM update

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2214,6 +2214,8 @@ void HandleOCODetectionFor(const string system)
          return;
       }
 
+      ProcessClosedTrades(system, false);
+
       RefreshRates();
       double price = (type == OP_BUY) ? Ask : Bid;
       double dist = DistanceToExistingPositions(price);


### PR DESCRIPTION
## Summary
- ensure HandleOCODetectionFor records closed trades before re-entry
- keep lastCloseTime in sync without updating DMCMM on manual closes

## Testing
- `python3 - <<'PY' ... PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891043bd3008327a25633ff5db549b8