### PR TITLE
シーケンス短縮時に不要なGlobalVariableを削除

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -177,7 +177,18 @@ bool SaveDMCState(const string system,const CDecompMC &state,int &err)
       string seqParts[]; int n=StringSplit(parts[2],',',seqParts);
 
       string prefix="MoveCatcher_"+system+"_";
-      ResetLastError(); GlobalVariableSet(prefix+"stock",stock); int e=GetLastError(); if(e!=0){if(err==0)err=e; ok=false;}
+
+      int prevN=0;
+      ResetLastError(); double prevSize=GlobalVariableGet(prefix+"seq_size"); int e=GetLastError();
+      if(e==0) prevN=(int)prevSize;
+
+      for(int i=n;i<prevN;i++)
+      {
+         string name=prefix+"seq_"+IntegerToString(i);
+         ResetLastError(); GlobalVariableDel(name); e=GetLastError(); if(e!=0){if(err==0)err=e; ok=false;}
+      }
+
+      ResetLastError(); GlobalVariableSet(prefix+"stock",stock); e=GetLastError(); if(e!=0){if(err==0)err=e; ok=false;}
       ResetLastError(); GlobalVariableSet(prefix+"streak",streak); e=GetLastError(); if(e!=0){if(err==0)err=e; ok=false;}
       ResetLastError(); GlobalVariableSet(prefix+"seq_size",n); e=GetLastError(); if(e!=0){if(err==0)err=e; ok=false;}
       for(int i=0;i<n;i++)


### PR DESCRIPTION
## 概要
- SaveDMCStateで既存のseq_sizeを読み取り、短縮分のGlobalVariableを削除
- 現在のシーケンスのみを保存し直す

## テスト
- `python -m pytest -q`
- 短縮シーケンスを用いたPythonシミュレーションで、不要なGlobalVariableが残らないことを確認

------
https://chatgpt.com/codex/tasks/task_e_68910921f87c8327b2aa8c474eb6aaad