### PR TITLE
Call duplicate position correction before OCO detection

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2545,9 +2545,10 @@ int OnInit()
 
 void OnTick()
 {
-   // OCO detection should run once per tick at the beginning
-   HandleOCODetection();
+   // Correct duplicate positions before OCO detection
    CorrectDuplicatePositions();
+   // OCO detection should run once per tick after correction
+   HandleOCODetection();
 
    SystemState prevA = state_A;
    SystemState prevB = state_B;


### PR DESCRIPTION
## Summary
- ensure CorrectDuplicatePositions runs before HandleOCODetection in OnTick

## Testing
- `wine metaeditor.exe /log /compile:experts/MoveCatcher.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891103b9ea08327834eadeb40d8ae17