### PR TITLE
未決済注文も距離計算に含めるよう修正

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -263,7 +263,10 @@ double DistanceToExistingPositions(const double price)
       if(OrderMagicNumber() != MagicNumber || OrderSymbol() != Symbol())
          continue;
       int type = OrderType();
-      if(type != OP_BUY && type != OP_SELL)
+      // 成立済みポジションに加え、未決済の指値・逆指値注文も距離計算に含める
+      if(type != OP_BUY && type != OP_SELL &&
+         type != OP_BUYLIMIT && type != OP_SELLLIMIT &&
+         type != OP_BUYSTOP  && type != OP_SELLSTOP)
          continue;
       double d = MathAbs(price - OrderOpenPrice());
       if(d < minDist)


### PR DESCRIPTION
## Summary
- DistanceToExistingPositions で未決済注文（指値・逆指値）も対象に追加

## Testing
- `make test` *(No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6891193b209c8327b59dd7e7a3b8303b