### PR TITLE
Use MathRound for slippage calculations

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -953,7 +953,7 @@ void RecoverAfterSL(const string system)
       return;
 
    bool   isBuy    = (lastType == OP_BUY);
-   int    slippage = UseProtectedLimit ? (int)(SlippagePips * Pip() / Point) : 0;
+   int    slippage = UseProtectedLimit ? (int)MathRound(SlippagePips * Pip() / Point) : 0;
    double price    = isBuy ? Ask : Bid;
    double sl       = NormalizeDouble(isBuy ? price - PipsToPrice(GridPips) : price + PipsToPrice(GridPips), Digits);
    double tp       = NormalizeDouble(isBuy ? price + PipsToPrice(GridPips) : price - PipsToPrice(GridPips), Digits);
@@ -1638,7 +1638,7 @@ bool InitStrategy()
    if(lotA <= 0) return(false);
 
    bool isBuy = (MathRand() % 2) == 0;
-   int    slippage = (int)(SlippagePips * Pip() / Point);
+   int    slippage = (int)MathRound(SlippagePips * Pip() / Point);
    double price    = isBuy ? Ask : Bid;
    double entrySL, entryTP;
    if(isBuy)
@@ -2270,7 +2270,7 @@ void HandleOCODetectionFor(const string system)
             retryTicketB = -1;
          return;
       }
-      int    slippage = UseProtectedLimit ? (int)(SlippagePips * Pip() / Point) : 0;
+      int    slippage = UseProtectedLimit ? (int)MathRound(SlippagePips * Pip() / Point) : 0;
       int newTicket = OrderSend(Symbol(), type, expectedLot, price,
                                 slippage, 0, 0,
                                 expectedComment, MagicNumber, 0, clrNONE);


### PR DESCRIPTION
## Summary
- ensure slippage uses MathRound to convert pips to integer points in RecoverAfterSL
- apply rounded slippage in InitStrategy
- round slippage calculation when reopening orders in HandleOCODetectionFor

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689122cd255c832780f033a0de1c9917