### PR TITLE
EnsureTPSL成功時のログ追記

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -691,6 +691,36 @@ void EnsureTPSL(const int ticket)
          lr.ErrorCode  = err;
          WriteLog(lr);
       }
+      else
+      {
+         if(OrderSelect(ticket, SELECT_BY_TICKET))
+         {
+            string sys, seq;
+            ParseComment(OrderComment(), sys, seq);
+            LogRecord lr;
+            lr.Time       = TimeCurrent();
+            lr.Symbol     = Symbol();
+            lr.System     = sys;
+            lr.Reason     = "REFILL";
+            lr.Spread     = PriceToPips(Ask - Bid);
+            lr.Dist       = 0;
+            lr.GridPips   = GridPips;
+            lr.s          = s;
+            lr.lotFactor  = 0;
+            lr.BaseLot    = BaseLot;
+            lr.MaxLot     = MaxLot;
+            lr.actualLot  = OrderLots();
+            lr.seqStr     = seq;
+            lr.CommentTag = OrderComment();
+            lr.Magic      = MagicNumber;
+            lr.OrderType  = OrderTypeToStr(OrderType());
+            lr.EntryPrice = entry;
+            lr.SL         = OrderStopLoss();
+            lr.TP         = OrderTakeProfit();
+            lr.ErrorCode  = 0;
+            WriteLog(lr);
+         }
+      }
    }
 }
 


### PR DESCRIPTION
## Summary
- Log REFILL when OrderModify succeeds in EnsureTPSL

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689136bb4f508327b9b12facd1994fc8