### PR TITLE
Log comment tag for LOT_RESET events

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -389,7 +389,7 @@ double CalcLot(const string system,string &seq,double &lotFactor)
       lr.MaxLot     = MaxLot;
       lr.actualLot  = lotActual;
       lr.seqStr     = seq;
-      lr.CommentTag = "";
+      lr.CommentTag = MakeComment(system, seq);
       lr.Magic      = MagicNumber;
       lr.OrderType  = "";
       lr.EntryPrice = 0;


### PR DESCRIPTION
## Summary
- record MakeComment output in LogRecord when MaxLot triggers LOT_RESET

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6891389c3f048327ad9338871896f93f