### PR TITLE
Persist DMC state after lot reset

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -366,6 +366,8 @@ double CalcLot(const string system,string &seq,double &lotFactor)
    if(lotCandidate > MaxLot)
    {
       state.Init();
+      int err = 0;
+      SaveDMCState(system, *state, err);
 
       lotFactor    = state.NextLot();
       seq          = "(" + state.Seq() + ")";
@@ -395,7 +397,7 @@ double CalcLot(const string system,string &seq,double &lotFactor)
       lr.EntryPrice = 0;
       lr.SL         = 0;
       lr.TP         = 0;
-      lr.ErrorCode  = 0;
+      lr.ErrorCode  = err;
       WriteLog(lr);
 
       return(lotActual);


### PR DESCRIPTION
## Summary
- persist DMC state after lot resets and log persistence errors

## Testing
- `wine metaeditor.exe /compile:experts/MoveCatcher.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68914024dcc883278c1fa4fa3e4b8134