### PR TITLE
feat: save DMC state after closed trades

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -577,6 +577,14 @@ void ProcessClosedTrades(const string system,const bool updateDMC)
       lr.SL         = OrderStopLoss();
       lr.TP         = OrderTakeProfit();
       lr.ErrorCode  = 0;
+      if(updateDMC)
+      {
+         int err = 0;
+         bool saved = SaveDMCState(system, (system == "A") ? stateA : stateB, err);
+         PrintFormat("SaveDMCState(%s) err=%d", system, err);
+         if(!saved)
+            lr.ErrorCode = err;
+      }
       WriteLog(lr);
    }
 }


### PR DESCRIPTION
## Summary
- save DMC state after processing closed trades
- log SaveDMCState error codes in both terminal and log records

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68914ada7b8483279ed8490aa77ec5dc