### PR TITLE
MaxSpreadPips 判定を HandleOCODetectionFor に追加

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2338,6 +2338,39 @@ void HandleOCODetectionFor(const string system)
             retryTicketB = -1;
          return;
       }
+      double spread = PriceToPips(Ask - Bid);
+      if(spread > MaxSpreadPips)
+      {
+         LogRecord lrSkip;
+         lrSkip.Time       = TimeCurrent();
+         lrSkip.Symbol     = Symbol();
+         lrSkip.System     = system;
+         lrSkip.Reason     = "REFILL";
+         lrSkip.Spread     = spread;
+         lrSkip.Dist       = (dist >= 0) ? dist : 0;
+         lrSkip.GridPips   = GridPips;
+         lrSkip.s          = s;
+         lrSkip.lotFactor  = lotFactorAdj;
+         lrSkip.BaseLot    = BaseLot;
+         lrSkip.MaxLot     = MaxLot;
+         lrSkip.actualLot  = expectedLot;
+         lrSkip.seqStr     = seqAdj;
+         lrSkip.CommentTag = expectedComment;
+         lrSkip.Magic      = MagicNumber;
+         lrSkip.OrderType  = OrderTypeToStr(type);
+         lrSkip.EntryPrice = price;
+         lrSkip.SL         = 0;
+         lrSkip.TP         = 0;
+         lrSkip.ErrorCode  = 0;
+         WriteLog(lrSkip);
+         PrintFormat("HandleOCODetectionFor: spread %.1f exceeds MaxSpreadPips %.1f, order skipped",
+                     spread, MaxSpreadPips);
+         if(system == "A")
+            retryTicketA = -1;
+         else
+            retryTicketB = -1;
+         return;
+      }
       int    slippage = UseProtectedLimit ? (int)MathRound(SlippagePips * Pip() / Point) : 0;
       int newTicket = OrderSend(Symbol(), type, expectedLot, price,
                                 slippage, 0, 0,


### PR DESCRIPTION
## Summary
- OrderSend 前にスプレッドをチェックし、MaxSpreadPips 超過時は発注をスキップ
- スキップ理由をログに記録

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891a4cbe00483279624a26bfef30912