### PR TITLE
Handle SaveDMCState errors conditionally

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -588,9 +588,12 @@ void ProcessClosedTrades(const string system,const bool updateDMC,const string r
       {
          int err = 0;
          bool saved = SaveDMCState(system, (system == "A") ? stateA : stateB, err);
-         PrintFormat("SaveDMCState(%s) err=%d", system, err);
          if(!saved)
+         {
+            if(err != 0)
+               PrintFormat("SaveDMCState(%s) err=%d", system, err);
             lr.ErrorCode = err;
+         }
       }
       WriteLog(lr);
    }


### PR DESCRIPTION
## Summary
- Only log SaveDMCState errors when the save fails and an error code is returned

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6891a7ced10083279ad883107da421f5