### PR TITLE
MathLog を用いたロット桁数計算への置き換え

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -161,7 +161,7 @@ double NormalizeLot(const double lotCandidate)
    if(lotStep > 0)
    {
       lot = MathRound(lot / lotStep) * lotStep;
-      lotDigits = (int)MathRound(-MathLog10(lotStep));
+      lotDigits = (int)MathRound(-MathLog(lotStep) / MathLog(10));
       lot = NormalizeDouble(lot, lotDigits);
    }
 


### PR DESCRIPTION
## Summary
- MathLog10 を使用していたロット桁数計算を MathLog で再実装
- 新しい桁数で NormalizeDouble を実行し、丸め処理を維持

## Testing
- `python - <<'PY' ...` (ロット桁数と丸め結果を確認)
- `make test` (対象なし)


------
https://chatgpt.com/codex/tasks/task_e_68922b96f54883279e512b5b47acaeca