### PR TITLE
Replace numeric error code with constant

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -884,7 +884,7 @@ void EnsureShadowOrder(const int ticket,const string system)
       lrs.SL         = 0;
       lrs.TP         = 0;
       // Stop level violation
-      lrs.ErrorCode  = 130;
+      lrs.ErrorCode  = ERR_INVALID_STOPS;
       WriteLog(lrs);
       PrintFormat("EnsureShadowOrder: price %.5f within stop level %.1f pips, retry next tick", price, PriceToPips(stopLevel));
       return;


### PR DESCRIPTION
## Summary
- use ERR_INVALID_STOPS instead of literal 130 when shadow order violates stop level
- confirm no other numeric error codes remain

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68923c09c2a48327bf07b212c8b026e9