### PR TITLE
ログ出力と距離帯違反検知の改善

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2150,7 +2150,7 @@ bool InitStrategy()
             lrS.SL         = 0;
             lrS.TP         = 0;
             lrS.ErrorCode  = 0;
-            lrS.ErrorInfo  = errS;
+            lrS.ErrorInfo  = (errS == "DistanceBandViolation") ? "Distance band violation" : errS;
             WriteLog(lrS);
             okSell = false;
          }
@@ -2286,7 +2286,7 @@ bool InitStrategy()
             lrB.SL         = 0;
             lrB.TP         = 0;
             lrB.ErrorCode  = 0;
-            lrB.ErrorInfo  = errB;
+            lrB.ErrorInfo  = (errB == "DistanceBandViolation") ? "Distance band violation" : errB;
             WriteLog(lrB);
             okBuy = false;
          }


### PR DESCRIPTION
## Summary
- B系統のSellLimit/BuyLimitで距離帯違反を検知した際、`okSell`/`okBuy`を無効化する前にログへ"Distance band violation"を記録するよう調整

## Testing
- `make test` *(テストターゲット無しで失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68927978fa0c8327bfd29c853230e878