### PR TITLE
Disable spread check in RecoverAfterSL

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1158,6 +1158,7 @@ void RecoverAfterSL(const string system)
    }
    string comment  = MakeComment(system, seq);
    double dist     = DistanceToExistingPositions(price);
+   /* Disabled spread check to allow market re-entry regardless of current spread
    if(spread > MaxSpreadPips)
    {
       LogRecord lrSkip;
@@ -1185,6 +1186,7 @@ void RecoverAfterSL(const string system)
       PrintFormat("RecoverAfterSL: spread %.1f > MaxSpreadPips %.1f, order skipped", spread, MaxSpreadPips);
       return;
    }
+   */
    if(UseDistanceBand && dist >= 0 && (dist < MinDistancePips || dist > MaxDistancePips))
    {
       LogRecord lrSkip;


### PR DESCRIPTION
## Summary
- disable spread gate in RecoverAfterSL so market re-entry occurs regardless of spread

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68928c772a7c8327832be2ea5702065e