### PR TITLE
Ensure shadow order price normalization

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -949,6 +949,7 @@ void EnsureShadowOrder(const int ticket,const string system)
       PrintFormat("EnsureShadowOrder: replaced shadow order for %s", system);
    }
 
+   price = NormalizeDouble(price, Digits);
    int tk = OrderSend(Symbol(), type, lot, price, 0, 0, 0, comment, MagicNumber, 0, clrNONE);
    LogRecord lr;
    lr.Time       = TimeCurrent();


### PR DESCRIPTION
## Summary
- 正規化された価格を OrderSend 前に適用し、指値送信時の桁数を保証

## Testing
- `pre-commit run --files experts/MoveCatcher.mq4` (`.pre-commit-config.yaml is not a file`)
- `make test` (No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68929d8547a08327bd3d83f1baa14c1d