### PR TITLE
fix lot normalization before MaxLot clipping

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -158,7 +158,7 @@ double NormalizeLot(const double lotCandidate)
    double lotStep = MarketInfo(Symbol(), MODE_LOTSTEP);
 
    double lot = lotCandidate;
-   int lotDigits = 0;
+   int    lotDigits = 0;
    if(lotStep > 0)
    {
       lot = MathRound(lot / lotStep) * lotStep;
@@ -170,8 +170,15 @@ double NormalizeLot(const double lotCandidate)
       lot = minLot;
    if(lot > maxLot)
       lot = maxLot;
-   if(lot > MaxLot)
-      lot = MaxLot;
+
+   double maxLotNorm = MaxLot;
+   if(lotStep > 0)
+   {
+      maxLotNorm = MathFloor(MaxLot / lotStep) * lotStep;
+      maxLotNorm = NormalizeDouble(maxLotNorm, lotDigits);
+   }
+   if(lot > maxLotNorm)
+      lot = maxLotNorm;
 
    return(NormalizeDouble(lot, lotDigits));
 }


### PR DESCRIPTION
## Summary
- normalize lot size before applying MaxLot clipping
- ensure normalized value never exceeds MaxLot

## Testing
- `make test` (no rule to make target `test`)


------
https://chatgpt.com/codex/tasks/task_e_68930415244c83278160d31bbc59026d