### PR TITLE
Disable distance band check in RecoverAfterSL

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1114,6 +1114,7 @@ void RecoverAfterSL(const string system)
       return;
    }
    */
+   /* Disabled distance band check to allow SL recovery regardless of distance
    if(UseDistanceBand && dist >= 0 && (dist < MinDistancePips || dist > MaxDistancePips))
    {
       LogRecord lrSkip;
@@ -1142,6 +1143,7 @@ void RecoverAfterSL(const string system)
                   dist, MinDistancePips, MaxDistancePips);
       return;
    }
+   */
    int type        = isBuy ? OP_BUY : OP_SELL;
    int ticket      = OrderSend(Symbol(), type, lot, price,
                                slippage, sl, tp, comment, MagicNumber, 0, clrNONE);


### PR DESCRIPTION
## Summary
- allow SL recovery regardless of distance by disabling distance-band filtering

## Testing
- `mql4 -q 2>&1 | head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935089223c8327b7b0c035430c2b97