### PR TITLE
Ensure comments are capped at 31 characters

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -452,7 +452,34 @@ double CalcLot(const string system,string &seq,double &lotFactor)
 //+------------------------------------------------------------------+
 string MakeComment(const string system,const string seq)
 {
-   return StringFormat("MoveCatcher_%s_%s", system, seq);
+   string comment = StringFormat("MoveCatcher_%s_%s", system, seq);
+   if(StringLen(comment) <= 31)
+      return(comment);
+
+   string compactSeq = "";
+   for(int i=0; i<StringLen(seq); i++)
+   {
+      int ch = StringGetChar(seq, i);
+      if(ch=='(' || ch==')' || ch==' ')
+         continue;
+      compactSeq += StringSubstr(seq, i, 1);
+   }
+   comment = StringFormat("MoveCatcher_%s_%s", system, compactSeq);
+   if(StringLen(comment) <= 31)
+      return(comment);
+
+   ulong hash = 0;
+   for(int j=0; j<StringLen(seq); j++)
+      hash = (hash * 131 + StringGetChar(seq, j)) & 0x7FFFFFFF;
+   string hashStr = IntegerToString((int)hash, 16);
+   comment = StringFormat("MoveCatcher_%s_%s", system, hashStr);
+   if(StringLen(comment) > 31)
+   {
+      int allowed = 31 - StringLen(StringFormat("MoveCatcher_%s_", system));
+      hashStr = StringSubstr(hashStr, 0, allowed);
+      comment = StringFormat("MoveCatcher_%s_%s", system, hashStr);
+   }
+   return(comment);
 }
 
 //+------------------------------------------------------------------+

--- a/tests/test_make_comment.py
+++ b/tests/test_make_comment.py
@@ -1,0 +1,37 @@
+import string
+
+
+def make_comment(system: str, seq: str) -> str:
+    comment = f"MoveCatcher_{system}_{seq}"
+    if len(comment) <= 31:
+        return comment
+
+    compact_seq = ''.join(ch for ch in seq if ch not in '() ')
+    comment = f"MoveCatcher_{system}_{compact_seq}"
+    if len(comment) <= 31:
+        return comment
+
+    h = 0
+    for ch in seq:
+        h = (h * 131 + ord(ch)) & 0x7FFFFFFF
+    hash_str = format(h, 'x')
+    comment = f"MoveCatcher_{system}_{hash_str}"
+    if len(comment) > 31:
+        allowed = 31 - len(f"MoveCatcher_{system}_")
+        hash_str = hash_str[:allowed]
+        comment = f"MoveCatcher_{system}_{hash_str}"
+    return comment
+
+
+def test_make_comment_length():
+    samples = [
+        "(0,1)",
+        "(0,1,2,3,4,5,6,7,8,9)",
+        "(" + ",".join(str(i) for i in range(30)) + ")",
+        "(" + ",".join(str(i) for i in range(100)) + ")",
+    ]
+    for seq in samples:
+        for system in ['A', 'B']:
+            comment = make_comment(system, seq)
+            assert len(comment) <= 31
+            assert comment.startswith(f"MoveCatcher_{system}_")


### PR DESCRIPTION
## Summary
- restrict MakeComment output to 31 characters by compacting or hashing sequence
- add Python tests verifying comment length limit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689352043b248327b17756aa08c7abbc