### PR TITLE
Fix undefined spread variable in RecoverAfterSL

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1115,6 +1115,7 @@ void RecoverAfterSL(const string system)
                   oldTP, tp, PriceToPips(minLevel));
    }
    string comment  = MakeComment(system, seq);
+   double spread   = PriceToPips(Ask - Bid);
    double dist     = DistanceToExistingPositions(price);
    /* Disabled spread check to allow market re-entry regardless of current spread
    if(spread > MaxSpreadPips)


### PR DESCRIPTION
## Summary
- compute spread in RecoverAfterSL and use it for logging

## Testing
- `pytest`
- `wine metaeditor64.exe /compile:experts/MoveCatcher.mq4 /log` *(fails: /usr/bin/wine: 40: exec: /usr/lib/wine/wine: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68936f19536483279c28fd9ca3348e6a