### PR TITLE
Normalize order price in CanPlaceOrder

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -309,6 +309,7 @@ bool CanPlaceOrder(double &price,const bool isBuy,string &errorInfo,bool checkSp
 
    // 注文方向に応じた基準価格を取得
    double ref  = isBuy ? Ask : Bid;
+   price       = NormalizeDouble(price, Digits);
    double dist = price - ref;
 
    // 方向チェック: BuyLimit は Ask 未満 / SellLimit は Bid 超過
@@ -375,6 +376,7 @@ bool CanPlaceOrder(double &price,const bool isBuy,string &errorInfo,bool checkSp
       }
    }
 
+   price     = NormalizeDouble(price, Digits);
    errorInfo = "";
    return(true);
 }


### PR DESCRIPTION
## Summary
- Normalize pending order prices to symbol digits
- Ensure normalized price is returned from `CanPlaceOrder`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893731a093883279109196a7a49b6f3