### PR TITLE
Normalize refill order prices

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1548,6 +1548,8 @@ void PlaceRefillOrders(const string system,const double refPrice)
    string comment  = MakeComment(system, seq);
    double priceSell = refPrice + PipsToPrice(s);
    double priceBuy  = refPrice - PipsToPrice(s);
+   priceSell = NormalizeDouble(priceSell, Digits);
+   priceBuy  = NormalizeDouble(priceBuy, Digits);
 
    double stopLevel   = MarketInfo(Symbol(), MODE_STOPLEVEL) * Point;
    double freezeLevel = MarketInfo(Symbol(), MODE_FREEZELEVEL) * Point;


### PR DESCRIPTION
## Summary
- normalize refill order prices using `NormalizeDouble`
- ensure normalized prices used in `CanPlaceOrder` and `OrderSend`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689378a741688327bcfaea15a9af51fb