### PR TITLE
成行発注のslippage計算を設定値に統一

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1089,7 +1089,7 @@ void RecoverAfterSL(const string system)
       return;
 
    bool   isBuy    = (lastType == OP_BUY);
-   int    slippage = UseProtectedLimit ? (int)MathRound(SlippagePips * Pip() / Point) : 0;
+   int    slippage = (int)MathRound(SlippagePips * Pip() / Point);
    double price    = isBuy ? Ask : Bid;
    double sl       = NormalizeDouble(isBuy ? price - PipsToPrice(GridPips) : price + PipsToPrice(GridPips), Digits);
    double tp       = NormalizeDouble(isBuy ? price + PipsToPrice(GridPips) : price - PipsToPrice(GridPips), Digits);
@@ -2572,7 +2572,7 @@ void HandleOCODetectionFor(const string system)
             retryTicketB = -1;
          return;
       }
-      slippage = UseProtectedLimit ? (int)MathRound(SlippagePips * Pip() / Point) : 0;
+      slippage = (int)MathRound(SlippagePips * Pip() / Point);
       double slInit, tpInit;
       if(type == OP_BUY)
       {


### PR DESCRIPTION
## 概要
- SL復帰時にUseProtectedLimitの設定に関わらずSlippagePipsからslippageを算出
- OCO検出後の再建ポジションでも同様にslippageを統一
- 成行発注箇所を再確認しslippage引数が適切に渡されることを確認

## テスト
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68939d8621048327bfbfe3373a29ca05