### PR TITLE
Ensure lowercase hash in MakeComment

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -475,7 +475,7 @@ string MakeComment(const string system,const string seq)
    ulong hash = 0;
    for(int j=0; j<StringLen(seq); j++)
       hash = (hash * 131 + StringGetChar(seq, j)) & 0x7FFFFFFF;
-   string hashStr = IntegerToString((int)hash, 16);
+   string hashStr = StringToLower(IntegerToString((int)hash, 16));
    comment = StringFormat("MoveCatcher_%s_%s", system, hashStr);
    if(StringLen(comment) > 31)
    {

--- a/tests/test_make_comment.py
+++ b/tests/test_make_comment.py
@@ -35,3 +35,11 @@ def test_make_comment_length():
             comment = make_comment(system, seq)
             assert len(comment) <= 31
             assert comment.startswith(f"MoveCatcher_{system}_")
+
+
+def test_hash_string_lowercase():
+    seq = "(" + ",".join(str(i) for i in range(100)) + ")"
+    for system in ['A', 'B']:
+        comment = make_comment(system, seq)
+        hash_part = comment.split("_")[-1]
+        assert hash_part == hash_part.lower()


### PR DESCRIPTION
## Summary
- Force MakeComment to lowercase hash strings for consistent comments
- Add unit test verifying hashed comment suffix is lowercase

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c60132e08327b161ccbca6eeae07