### PR TITLE
refactor: use tolerant lot comparison

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2536,7 +2536,9 @@ void HandleOCODetectionFor(const string system)
       return;
    }
    string expectedComment = MakeComment(system, seqAdj);
-   if(MathAbs(OrderLots() - expectedLot) > 1e-8 || OrderComment() != expectedComment)
+   double lotStep = MarketInfo(Symbol(), MODE_LOTSTEP);
+   double lotTol  = (lotStep > 0) ? lotStep * 0.5 : 1e-8;
+   if(MathAbs(OrderLots() - expectedLot) > lotTol || OrderComment() != expectedComment)
    {
       RefreshRates();
       double spreadClose = PriceToPips(Ask - Bid);


### PR DESCRIPTION
## Summary
- add lot step-based tolerance when comparing expected and actual lot sizes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d12e0d448327af1d8387d1363d5c