### PR TITLE
ProcessClosedTradesで距離計算をログに追加

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -634,13 +634,14 @@ void ProcessClosedTrades(const string system,const bool updateDMC,const string r
          if(times[i] > lastCloseTimeB)
             lastCloseTimeB = times[i];
       }
+      double dist = DistanceToExistingPositions(OrderOpenPrice(), OrderTicket());
       LogRecord lr;
       lr.Time       = times[i];
       lr.Symbol     = Symbol();
       lr.System     = system;
       lr.Reason     = rsn;
       lr.Spread     = spreadNow;
-      lr.Dist       = 0;
+      lr.Dist       = dist;
       lr.GridPips   = GridPips;
       lr.s          = s;
       lr.lotFactor  = 0;


### PR DESCRIPTION
## Summary
- Closedトレード処理時に既存ポジションとの距離を計算しログへ記録

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d1db451c8327af7704e44a1013ec