### PR TITLE
RecoverAfterSLでSlippagePipsを常に使用するよう修正

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1092,8 +1092,8 @@ void RecoverAfterSL(const string system)
       return;
 
    bool   isBuy    = (lastType == OP_BUY);
-   // Disable slippage when UseProtectedLimit is false
-   int    slippage = UseProtectedLimit ? (int)MathRound(SlippagePips * Pip() / Point) : 0;
+   // Use SlippagePips regardless of UseProtectedLimit
+   int    slippage = (int)MathRound(SlippagePips * Pip() / Point);
    double price    = isBuy ? Ask : Bid;
    double sl       = NormalizeDouble(isBuy ? price - PipsToPrice(GridPips) : price + PipsToPrice(GridPips), Digits);
    double tp       = NormalizeDouble(isBuy ? price + PipsToPrice(GridPips) : price - PipsToPrice(GridPips), Digits);


### PR DESCRIPTION
## Summary
- Remove UseProtectedLimit check and always apply SlippagePips in RecoverAfterSL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894594794c0832794d2f086feb519d0