### PR TITLE
距離帯違反時に影指値を出さずログ記録するよう修正

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -854,11 +854,17 @@ void EnsureShadowOrder(const int ticket,const string system)
    double bandDist = DistanceToExistingPositions(price, ticket);
 
    RefreshRates();
-   if(UseDistanceBand && bandDist >= 0 && (bandDist < MinDistancePips || bandDist > MaxDistancePips))
-      PrintFormat("EnsureShadowOrder: distance %.1f outside [%.1f, %.1f] - ignored for shadow order", bandDist, MinDistancePips, MaxDistancePips);
 
-   string errcp;
-   bool canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, false, ticket, false);
+   string errcp = "";
+   bool   canPlace = true;
+   if(UseDistanceBand && bandDist >= 0 && (bandDist < MinDistancePips || bandDist > MaxDistancePips))
+   {
+      PrintFormat("EnsureShadowOrder: distance %.1f outside [%.1f, %.1f] - no shadow order for %s", bandDist, MinDistancePips, MaxDistancePips, system);
+      errcp    = "DistanceBandViolation";
+      canPlace = false;
+   }
+   else
+      canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, false, ticket, true);
    if(!canPlace)
    {
       LogRecord lre;
@@ -869,7 +875,7 @@ void EnsureShadowOrder(const int ticket,const string system)
       lre.Spread     = PriceToPips(Ask - Bid);
       double logDist = GridPips;
       if(errcp == "DistanceBandViolation")
-         logDist = MathMax(DistanceToExistingPositions(price, ticket), 0);
+         logDist = MathMax(bandDist, 0);
       lre.Dist       = logDist;
       lre.GridPips   = GridPips;
       lre.s          = s;


### PR DESCRIPTION
## 概要
- EnsureShadowOrderで距離帯違反時は影指値を設置せずログ出力
- CanPlaceOrder呼び出しを距離帯チェック有効に変更

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68945e8111f48327b29f8f2264d12df3