### PR TITLE
Add StopLevel violation check after adjustment

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -359,6 +359,12 @@ bool CanPlaceOrder(double &price,const bool isBuy,string &errorInfo,
       }
    }
 
+   if(absDist < stopLevel)
+   {
+      errorInfo = "StopLevel violation";
+      return(false);
+   }
+
    double spread = PriceToPips(Ask - Bid);
    if(checkSpread && spread > MaxSpreadPips)
    {


### PR DESCRIPTION
## Summary
- ensure CanPlaceOrder rejects prices within StopLevel even after adjustment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894a11dd76c832796ba6da320bc45c1