### PR TITLE
Prevent duplicate closed trade handling

### DIFF
--- a/tests/test_process_closed_trades.py
+++ b/tests/test_process_closed_trades.py
@@ -1,32 +1,45 @@
 import pytest
 
 
-def process_closed_trades_py(history, system, last_time):
+def process_closed_trades_py(history, system, last_time, last_tickets):
     tickets = []
     times = []
     new_last_time = last_time
+    new_last_tickets = list(last_tickets)
     for order in history:
         if order["system"] != system:
             continue
         ct = order["close_time"]
         if ct < last_time:
             continue
+        if ct == last_time and order["ticket"] in last_tickets:
+            continue
         tickets.append(order["ticket"])
         times.append(ct)
         if ct > new_last_time:
             new_last_time = ct
-    return tickets, new_last_time
+            new_last_tickets = [order["ticket"]]
+        elif ct == new_last_time:
+            new_last_tickets.append(order["ticket"])
+    return tickets, new_last_time, new_last_tickets
 
 
 def test_same_time_closures_are_processed():
     history = [
         {"ticket": 1, "system": "A", "close_time": 100},
     ]
-    tickets, last_time = process_closed_trades_py(history, "A", 0)
+    tickets, last_time, last_tickets = process_closed_trades_py(history, "A", 0, [])
     assert tickets == [1]
 
     # 新しい注文が同一時刻で決済された場合でも処理されることを確認
     history.append({"ticket": 2, "system": "A", "close_time": 100})
-    tickets, last_time = process_closed_trades_py(history, "A", last_time)
-    assert 2 in tickets
+    tickets, last_time, last_tickets = process_closed_trades_py(history, "A", last_time, last_tickets)
+    assert tickets == [2]
     assert last_time == 100
+    assert set(last_tickets) == {1, 2}
+
+    # 既に処理済みの注文は再処理されないことを確認
+    tickets, last_time, last_tickets = process_closed_trades_py(history, "A", last_time, last_tickets)
+    assert tickets == []
+    assert last_time == 100
+    assert set(last_tickets) == {1, 2}


### PR DESCRIPTION
## Summary
- Track processed tickets per system to avoid duplicate closed trade processing
- Update closed trade processing to skip tickets with previous timestamps and store new tickets
- Extend Python tests to confirm same-timestamp trades are processed once

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ab534084832781c0b4682bdd14bf