### PR TITLE
RESET_SNAP・RESET_ALIVE後にInitCloseTimesを呼び出し

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -3009,6 +3009,7 @@ void OnTick()
             lr.ErrorCode  = 0;
             WriteLog(lr);
             CloseAllOrders("RESET_SNAP");
+            InitCloseTimes();
               state_A = None;
               state_B = None;
               if(!InitStrategy())
@@ -3051,6 +3052,7 @@ void OnTick()
          lr.ErrorCode  = 0;
          WriteLog(lr);
            CloseAllOrders("RESET_ALIVE");
+           InitCloseTimes();
            state_A = None;
            state_B = None;
            if(!InitStrategy())


### PR DESCRIPTION
## Summary
- RESET_SNAPとRESET_ALIVEのリセット処理直後にInitCloseTimes()を呼び出し、過去の決済情報をクリア

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ba75c1d08327b7010d73bbd4d864