### PR TITLE
Remove redundant stop level recheck in CanPlaceOrder

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -392,12 +392,6 @@ bool CanPlaceOrder(double &price,const bool isBuy,string &errorInfo,
       }
    }
 
-   if(absDist < stopLevel)
-   {
-      errorInfo = "StopLevel violation";
-      return(false);
-   }
-
    double spread = PriceToPips(Ask - Bid);
    if(checkSpread && spread > MaxSpreadPips)
    {


### PR DESCRIPTION
## Summary
- Simplify CanPlaceOrder by removing redundant StopLevel recheck after price adjustment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894bfa9347c83279c6851009baf219b