### PR TITLE
lotStep が無効な場合のロット処理を保護

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -172,32 +172,34 @@ double NormalizeLot(const double lotCandidate)
 
    if(lot < minLot)
       lot = minLot;
-  if(lot > maxLot)
-     lot = maxLot;
+   if(lot > maxLot)
+      lot = maxLot;
 
-  return(NormalizeDouble(lot, lotDigits));
+   if(lotStep > 0)
+      return(NormalizeDouble(lot, lotDigits));
+   return(lot);
 }
 
 double ClipToUserMax(const double lot)
 {
    double lotStep = MarketInfo(Symbol(), MODE_LOTSTEP);
-   int    lotDigits = 0;
-   double maxLotAdj = MaxLot;
-   if(lotStep > 0)
+   if(lotStep <= 0)
    {
-      lotDigits = (int)MathRound(-MathLog(lotStep) / MathLog(10));
-      maxLotAdj = MathFloor(MaxLot / lotStep) * lotStep;
-      maxLotAdj = NormalizeDouble(maxLotAdj, lotDigits);
+      double result = lot;
+      if(result > MaxLot)
+         result = MaxLot;
+      return(result);
    }
+
+   int    lotDigits = (int)MathRound(-MathLog(lotStep) / MathLog(10));
+   double maxLotAdj = MathFloor(MaxLot / lotStep) * lotStep;
+   maxLotAdj = NormalizeDouble(maxLotAdj, lotDigits);
 
    double result = lot;
    if(result > maxLotAdj)
       result = maxLotAdj;
 
-   if(lotStep > 0)
-      result = NormalizeDouble(result, lotDigits);
-
-   return(result);
+   return(NormalizeDouble(result, lotDigits));
 }
 
 void AddTicket(int &arr[],const int ticket)

--- a/tests/test_lot_limits.py
+++ b/tests/test_lot_limits.py
@@ -13,22 +13,22 @@ def normalize_lot(lot_candidate: float, min_lot: float, max_lot_broker: float, l
         lot = min_lot
     if lot > max_lot_broker:
         lot = max_lot_broker
-    return round(lot, lot_digits)
+    if lot_step > 0:
+        return round(lot, lot_digits)
+    return lot
 
 
 def clip_to_user_max(lot: float, user_max: float, lot_step: float) -> float:
-    lot_digits = 0
-    max_lot_adj = user_max
-    if lot_step > 0:
-        lot_digits = int(round(-math.log10(lot_step)))
-        max_lot_adj = math.floor(user_max / lot_step) * lot_step
-        max_lot_adj = round(max_lot_adj, lot_digits)
+    if lot_step <= 0:
+        return min(lot, user_max)
+
+    lot_digits = int(round(-math.log10(lot_step)))
+    max_lot_adj = math.floor(user_max / lot_step) * lot_step
+    max_lot_adj = round(max_lot_adj, lot_digits)
     result = lot
     if result > max_lot_adj:
         result = max_lot_adj
-    if lot_step > 0:
-        result = round(result, lot_digits)
-    return result
+    return round(result, lot_digits)
 
 
 def calc_lot(lot_candidate: float, user_max: float, min_lot: float, max_lot_broker: float, lot_step: float) -> float:
@@ -44,6 +44,7 @@ def calc_lot(lot_candidate: float, user_max: float, min_lot: float, max_lot_brok
         (0.05, 1.0, 0.1, 10.0, 0.1, 0.1),
         (2.0, 1.5, 0.01, 10.0, 0.01, 1.5),
         (1.4, 1.45, 0.01, 2.0, 0.3, 1.2),
+        (0.123, 1.0, 0.01, 10.0, 0.0, 0.123),
     ],
 )
 


### PR DESCRIPTION
## 概要
- lotStep が 0 以下の場合、NormalizeLot が丸めを行わずブローカー情報をそのまま使用
- ClipToUserMax でも lotStep が無効な際にユーザー上限のみを適用
- lotStep が 0 のケースを検証するテストを追加

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c1cbfdd0832792c85c514e06d346