### PR TITLE
ProcessClosedTradesでTP/SL判定を強化

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -697,10 +697,24 @@ void ProcessClosedTrades(const string system,const bool updateDMC,const string r
          double tol        = Point * 0.5;
          bool isTP = (MathAbs(closePrice - OrderTakeProfit()) <= tol);
          bool isSL = (MathAbs(closePrice - OrderStopLoss())  <= tol);
-         if(!isTP && !isSL)
-            rsn = ((OrderProfit() + OrderSwap() + OrderCommission()) >= 0) ? "TP" : "SL";
-         else
+         if(isTP || isSL)
             rsn = isTP ? "TP" : "SL";
+         else
+         {
+            string cmt = OrderComment();
+            if(StringFind(cmt, "TP") >= 0)
+               rsn = "TP";
+            else if(StringFind(cmt, "SL") >= 0)
+               rsn = "SL";
+            else
+            {
+               double openPrice = OrderOpenPrice();
+               if(OrderType() == OP_BUY)
+                  rsn = (closePrice >= openPrice) ? "TP" : "SL";
+               else
+                  rsn = (closePrice <= openPrice) ? "TP" : "SL";
+            }
+         }
       }
 
       bool win = (rsn == "TP");

--- a/tests/test_close_reason.py
+++ b/tests/test_close_reason.py
@@ -1,0 +1,33 @@
+import pytest
+
+
+def estimate_reason(order):
+    point = order.get("point", 0.00001)
+    tol = point * 0.5
+    close_price = order["close"]
+    tp = order.get("tp", 0)
+    sl = order.get("sl", 0)
+    is_tp = abs(close_price - tp) <= tol and tp != 0
+    is_sl = abs(close_price - sl) <= tol and sl != 0
+    if is_tp or is_sl:
+        return "TP" if is_tp else "SL"
+    comment = order.get("comment", "")
+    if "TP" in comment:
+        return "TP"
+    if "SL" in comment:
+        return "SL"
+    open_price = order["open"]
+    if order["type"] == "buy":
+        return "TP" if close_price >= open_price else "SL"
+    return "TP" if close_price <= open_price else "SL"
+
+
+def test_reason_uses_price_when_profit_near_zero():
+    buy_order = {"type": "buy", "open": 1.0, "close": 1.00001}
+    assert estimate_reason(buy_order) == "TP"
+    sell_order = {"type": "sell", "open": 1.0, "close": 0.99999}
+    assert estimate_reason(sell_order) == "TP"
+    buy_loss = {"type": "buy", "open": 1.0, "close": 0.99999}
+    assert estimate_reason(buy_loss) == "SL"
+    sell_loss = {"type": "sell", "open": 1.0, "close": 1.00001}
+    assert estimate_reason(sell_loss) == "SL"


### PR DESCRIPTION
## Summary
- TP/SL推定時に決済価格との比較を最優先し、コメントや注文方向を利用して決済理由を補完
- 決済理由推定の単体テストを追加

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c37bf4588327af5793d55c2518f4