### PR TITLE
ProcessClosedTrades の距離ログを0以上に補正

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -729,6 +729,7 @@ void ProcessClosedTrades(const string system,const bool updateDMC,const string r
             stateB.OnTrade(win);
       }
       double dist = DistanceToExistingPositions(OrderOpenPrice(), OrderTicket());
+      dist = MathMax(dist, 0);
       LogRecord lr;
       lr.Time       = times[i];
       lr.Symbol     = Symbol();


### PR DESCRIPTION
## Summary
- DistanceToExistingPositions の値を MathMax で 0 以上に補正してログに記録

## Testing
- `pytest -q`
- 簡易スクリプトで負の距離が 0 としてログされることを確認

------
https://chatgpt.com/codex/tasks/task_e_6894d0eb25108327a551cb1d4db24a4e