### PR TITLE
補充指値設置時の復帰処理を抑止

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -3013,12 +3013,18 @@ void OnTick()
       if(hasA && !hasB && !pendB && ticketA != -1)
       {
          if(OrderSelect(ticketA, SELECT_BY_TICKET))
+         {
             PlaceRefillOrders("B", OrderOpenPrice());
+            pendB = true;
+         }
       }
       else if(hasB && !hasA && !pendA && ticketB != -1)
       {
          if(OrderSelect(ticketB, SELECT_BY_TICKET))
+         {
             PlaceRefillOrders("A", OrderOpenPrice());
+            pendA = true;
+         }
       }
    }
 
@@ -3030,9 +3036,9 @@ void OnTick()
    if(hasB && shadowRetryB)
       EnsureShadowOrder(ticketB, "B");
 
-   if(state_A == Missing)
+   if(state_A == Missing && !pendA)
       RecoverAfterSL("A");
-   if(state_B == Missing)
+   if(state_B == Missing && !pendB)
       RecoverAfterSL("B");
 }
 


### PR DESCRIPTION
## 概要
- 補充指値を設置した際に `pend` フラグを即時更新
- `RecoverAfterSL` 呼び出し条件に `!pendA`/`!pendB` を追加し、未決済注文がある場合は復帰処理をスキップ

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894d5b10f7083279d50d8d03dbfd619