### PR TITLE
影指値の距離帯チェックを無効化

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -961,20 +961,16 @@ void EnsureShadowOrder(const int ticket,const string system)
    RefreshRates();
 
    string errcp = "";
-   bool   canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, false, ticket, true);
+   bool   canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, false, ticket, false);
    if(!canPlace)
    {
-      double bandDist = DistanceToExistingPositions(price, ticket);
       LogRecord lre;
       lre.Time       = TimeCurrent();
       lre.Symbol     = Symbol();
       lre.System     = system;
       lre.Reason     = "REFILL";
       lre.Spread     = PriceToPips(Ask - Bid);
-      double logDist = GridPips;
-      if(errcp == "DistanceBandViolation")
-         logDist = MathMax(bandDist, 0);
-      lre.Dist       = logDist;
+      lre.Dist       = GridPips;
       lre.GridPips   = GridPips;
       lre.s          = s;
       lre.lotFactor  = lotFactor;


### PR DESCRIPTION
## 概要
- 影指値設置時の `CanPlaceOrder` 呼び出しで距離帯チェックを無効化
- 距離帯違反に依存したログ処理を整理

## テスト
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894dc1e6dc083279e89c931668bb6aa