### PR TITLE
Remove MarketSlippagePips parameter and unify slippage

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ README.md                                  ← 本ドキュメント
 | `MaxSpreadPips`     | double | 例: 2.0                 | **置く前だけ**判定（初期OCO／補充／SL後の Pending 再建て）                 |
 | `UseProtectedLimit` |   bool | true/false              | **SL 復帰＝成行＋Slippage**（MT4 標準の価格保護）                           |
 | `SlippagePips`      | double | 例: 1.0                 | 成行の最大許容スリッページ（pips）                                      |
-| `MarketSlippagePips`| double | 例: 0.0                 | `UseProtectedLimit=false` 時の成行許容スリッページ（pips）          |
 | `UseDistanceBand`   |   bool | true/false              | true で発注前に距離帯 `[Min, Max]` をチェック                             |
 | `MinDistancePips`   | double | 例: 50                  | 距離帯下限（`UseDistanceBand=true` のとき有効）                            |
 | `MaxDistancePips`   | double | 例: 55                  | 距離帯上限（`UseDistanceBand=true` のとき有効）                            |

--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -10,7 +10,6 @@ input double EpsilonPips       = 1.0;   // Tolerance width (pips)
 input double MaxSpreadPips     = 2.0;   // Max spread when placing orders
 input bool   UseProtectedLimit = true;  // Use slippage-protected market orders after SL
 input double SlippagePips      = 1.0;   // Maximum slippage for market orders
-input double MarketSlippagePips = 0.0;   // Slippage when UseProtectedLimit=false
 input bool   UseDistanceBand   = false; // Filter by distance band before ordering
 input double MinDistancePips   = 50;    // Minimum distance (pips)
 input double MaxDistancePips   = 55;    // Maximum distance (pips)
@@ -1154,9 +1153,8 @@ void DeletePendings(const string system,const string reason)
 }
 
 //+------------------------------------------------------------------+
-//| Re-enter position after SL. Slippage from SlippagePips is used    |
-//| only when UseProtectedLimit=true; otherwise MarketSlippagePips or |
-//| zero is applied.                                                  |
+//| Re-enter position after SL. SlippagePips is always applied,       |
+//| while UseProtectedLimit only tags log output.                     |
 //+------------------------------------------------------------------+
 void RecoverAfterSL(const string system)
 {
@@ -1193,7 +1191,7 @@ void RecoverAfterSL(const string system)
       return;
 
    bool   isBuy    = (lastType == OP_BUY);
-   double reSlippagePips = UseProtectedLimit ? SlippagePips : MarketSlippagePips;
+   double reSlippagePips = SlippagePips;
    int    slippage = (int)MathRound(reSlippagePips * Pip() / Point);
    string flagInfo = UseProtectedLimit ? "UseProtectedLimit=true" : "UseProtectedLimit=false";
    double price    = isBuy ? Ask : Bid;
@@ -2827,11 +2825,6 @@ int OnInit()
    if(SlippagePips < 0)
    {
       Print("SlippagePips must be non-negative");
-      return(INIT_PARAMETERS_INCORRECT);
-   }
-   if(MarketSlippagePips < 0)
-   {
-      Print("MarketSlippagePips must be non-negative");
       return(INIT_PARAMETERS_INCORRECT);
    }
    if(UseDistanceBand)

--- a/tests/test_no_market_slippage.py
+++ b/tests/test_no_market_slippage.py
@@ -1,0 +1,7 @@
+import pathlib
+
+
+def test_no_market_slippage_parameter():
+    mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
+    content = mc_path.read_text(encoding="utf-8")
+    assert "MarketSlippagePips" not in content


### PR DESCRIPTION
## Summary
- drop legacy `MarketSlippagePips` input and validation, relying solely on `SlippagePips`
- simplify re-entry logic to use `SlippagePips` for all SL recoveries and adjust inline documentation
- document parameter removal and add regression test ensuring `MarketSlippagePips` stays absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ea650c5483278d1f743174c9d9c6