### PR TITLE
reuse stop level vars in RecoverAfterSL

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1267,9 +1267,9 @@ void RecoverAfterSL(const string system)
    double entry = OrderOpenPrice();
    double desiredSL = isBuy ? entry - PipsToPrice(GridPips) : entry + PipsToPrice(GridPips);
    double desiredTP = isBuy ? entry + PipsToPrice(GridPips) : entry - PipsToPrice(GridPips);
-   double stopLevel   = MarketInfo(Symbol(), MODE_STOPLEVEL) * Point;
-   double freezeLevel = MarketInfo(Symbol(), MODE_FREEZELEVEL) * Point;
-   double minLevel    = MathMax(stopLevel, freezeLevel);
+   stopLevel   = MarketInfo(Symbol(), MODE_STOPLEVEL) * Point;
+   freezeLevel = MarketInfo(Symbol(), MODE_FREEZELEVEL) * Point;
+   minLevel    = MathMax(stopLevel, freezeLevel);
    if(isBuy)
    {
       if(Bid - desiredSL < minLevel)


### PR DESCRIPTION
## Summary
- reuse predeclared stopLevel/freezeLevel/minLevel in RecoverAfterSL

## Testing
- `pytest`
- `wine metaeditor /compile experts/MoveCatcher.mq4 /log compile.log` *(fails: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_6894f310ee308327929957ac824e0ec7