### PR TITLE
影指値の距離帯判定を有効化

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -960,7 +960,7 @@ void EnsureShadowOrder(const int ticket,const string system)
    RefreshRates();
 
    string errcp = "";
-   bool   canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, false, ticket, false);
+   bool   canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, false, ticket, true);
    if(!canPlace)
    {
       LogRecord lre;

--- a/tests/test_shadow_order_distance_band.py
+++ b/tests/test_shadow_order_distance_band.py
@@ -1,0 +1,9 @@
+import pathlib
+import re
+
+
+def test_shadow_order_respects_distance_band():
+    mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
+    content = mc_path.read_text(encoding="utf-8")
+    pattern = r"CanPlaceOrder\s*\(\s*price\s*,\s*\(type == OP_BUYLIMIT\)\s*,\s*errcp\s*,\s*false\s*,\s*ticket\s*,\s*true\s*\)"
+    assert re.search(pattern, content), "UseDistanceBand=true の場合、影指値も距離帯判定を受けるべき"


### PR DESCRIPTION
## 概要
- EnsureShadowOrder で CanPlaceOrder に距離帯判定を有効化
- 影指値が距離帯判定を受けることを確認するテストを追加

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894f54a042483279816bda923380e89