### PR TITLE
Process closed trades during EA initialization

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2921,6 +2921,8 @@ int OnInit()
 
    MathSrand(GetTickCount());
    InitCloseTimes();
+   ProcessClosedTrades("A", true);
+   ProcessClosedTrades("B", true);
    if(hasAny)
       Print("Existing entries found, InitStrategy skipped");
    else


### PR DESCRIPTION
## Summary
- ensure OnInit replays unprocessed closed trades for systems A and B

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894f7f4a4a48327987f257f32093a27