### PR TITLE
Disable distance band check for shadow orders

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -960,9 +960,18 @@ void EnsureShadowOrder(const int ticket,const string system)
    RefreshRates();
 
    string errcp = "";
-   bool   canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, false, ticket, true);
+   bool   canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, false, ticket, false);
    if(!canPlace)
    {
+      if(errcp == "DistanceBandViolation")
+      {
+         if(system == "A")
+            shadowRetryA = true;
+         else
+            shadowRetryB = true;
+         return;
+      }
+
       LogRecord lre;
       lre.Time       = TimeCurrent();
       lre.Symbol     = Symbol();

--- a/tests/test_shadow_order_distance_band.py
+++ b/tests/test_shadow_order_distance_band.py
@@ -5,5 +5,5 @@ import re
 def test_shadow_order_respects_distance_band():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     content = mc_path.read_text(encoding="utf-8")
-    pattern = r"CanPlaceOrder\s*\(\s*price\s*,\s*\(type == OP_BUYLIMIT\)\s*,\s*errcp\s*,\s*false\s*,\s*ticket\s*,\s*true\s*\)"
-    assert re.search(pattern, content), "UseDistanceBand=true の場合、影指値も距離帯判定を受けるべき"
+    pattern = r"CanPlaceOrder\s*\(\s*price\s*,\s*\(type == OP_BUYLIMIT\)\s*,\s*errcp\s*,\s*false\s*,\s*ticket\s*,\s*false\s*\)"
+    assert re.search(pattern, content), "影指値では距離帯判定を行わない"


### PR DESCRIPTION
## Summary
- skip distance band validation when placing shadow TP orders
- suppress logging when distance band would block order
- adjust unit tests for new shadow order behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68950c5f7d1c83279c2ba191e71c1636