### PR TITLE
Apply slippage only when protected limit is enabled

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1164,8 +1164,8 @@ void DeletePendings(const string system,const string reason)
 }
 
 //+------------------------------------------------------------------+
-//| Re-enter position after SL. SlippagePips is always applied,       |
-//| while UseProtectedLimit only tags log output.                     |
+//| Re-enter position after SL. SlippagePips is applied only when     |
+//| UseProtectedLimit is true.                                        |
 //+------------------------------------------------------------------+
 void RecoverAfterSL(const string system)
 {
@@ -1202,9 +1202,18 @@ void RecoverAfterSL(const string system)
       return;
 
    bool   isBuy    = (lastType == OP_BUY);
-   double reSlippagePips = SlippagePips;
-   int    slippage = (int)MathRound(reSlippagePips * Pip() / Point);
-   string flagInfo = UseProtectedLimit ? "UseProtectedLimit=true" : "UseProtectedLimit=false";
+   int    slippage = 0;
+   string flagInfo;
+   if(UseProtectedLimit)
+   {
+      double reSlippagePips = SlippagePips;
+      slippage = (int)MathRound(reSlippagePips * Pip() / Point);
+      flagInfo = StringFormat("UseProtectedLimit=true slippage=%d", slippage);
+   }
+   else
+   {
+      flagInfo = "UseProtectedLimit=false slippage=0";
+   }
    RefreshRates();
    double price    = isBuy ? Ask : Bid;
    double sl       = NormalizeDouble(isBuy ? price - PipsToPrice(GridPips) : price + PipsToPrice(GridPips), Digits);

--- a/tests/test_recover_after_sl_slippage.py
+++ b/tests/test_recover_after_sl_slippage.py
@@ -1,0 +1,10 @@
+import pathlib
+
+
+def test_recover_after_sl_slippage_toggle():
+    mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
+    code = mc_path.read_text(encoding="utf-8")
+    assert "int    slippage = 0;" in code
+    assert "if(UseProtectedLimit)" in code
+    assert "slippage = (int)MathRound(reSlippagePips * Pip() / Point);" in code
+    assert "flagInfo = \"UseProtectedLimit=false slippage=0\";" in code


### PR DESCRIPTION
## Summary
- Recompute slippage only when `UseProtectedLimit` is true and include slippage info in logging
- Add test verifying slippage toggles after SL recovery

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68952c638d1c8327823bbb9fda471f54