### PR TITLE
影指値での距離帯分岐を整理

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -964,15 +964,6 @@ void EnsureShadowOrder(const int ticket,const string system)
    double distBand = MathMax(DistanceToExistingPositions(price, ticket), 0);
    if(!canPlace)
    {
-      if(errcp == "DistanceBandViolation")
-      {
-         if(system == "A")
-            shadowRetryA = true;
-         else
-            shadowRetryB = true;
-         return;
-      }
-
       LogRecord lre;
       lre.Time       = TimeCurrent();
       lre.Symbol     = Symbol();


### PR DESCRIPTION
## 概要
- 影指値設置時の `DistanceBandViolation` 判定を削除
- `CanPlaceOrder` 失敗時の処理を共通化し、エラーログ出力と再試行フラグ設定のみ行う

## テスト
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68952fc249e8832797e391bc3fe07ec5