### PR TITLE
InitStrategy にスプレッド判定を追加

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1938,6 +1938,38 @@ bool InitStrategy()
    int typeA   = isBuy ? OP_BUY : OP_SELL;
    RefreshRates();
    price = isBuy ? Ask : Bid;
+
+   double spread = PriceToPips(Ask - Bid);
+   if(spread > MaxSpreadPips)
+   {
+      LogRecord lrSkipA;
+      lrSkipA.Time       = TimeCurrent();
+      lrSkipA.Symbol     = Symbol();
+      lrSkipA.System     = "A";
+      lrSkipA.Reason     = "INIT";
+      lrSkipA.Spread     = spread;
+      lrSkipA.Dist       = MathMax(distA, 0);
+      lrSkipA.GridPips   = GridPips;
+      lrSkipA.s          = s;
+      lrSkipA.lotFactor  = lotFactorA;
+      lrSkipA.BaseLot    = BaseLot;
+      lrSkipA.MaxLot     = MaxLot;
+      lrSkipA.actualLot  = lotA;
+      lrSkipA.seqStr     = seqA;
+      lrSkipA.CommentTag = commentA;
+      lrSkipA.Magic      = MagicNumber;
+      lrSkipA.OrderType  = OrderTypeToStr(isBuy ? OP_BUY : OP_SELL);
+      lrSkipA.EntryPrice = price;
+      lrSkipA.SL         = entrySL;
+      lrSkipA.TP         = entryTP;
+      lrSkipA.ErrorCode  = 0;
+      lrSkipA.ErrorInfo  = "SpreadExceeded";
+      WriteLog(lrSkipA);
+      PrintFormat("InitStrategy: spread %.1f exceeds MaxSpreadPips %.1f, order skipped",
+                  spread, MaxSpreadPips);
+      return(false);
+   }
+
    ResetLastError();
    int ticketA = OrderSend(Symbol(), typeA, lotA, price,
                            slippage, entrySL, entryTP, commentA, MagicNumber, 0, clrNONE);

--- a/tests/test_init_strategy_spread_check.py
+++ b/tests/test_init_strategy_spread_check.py
@@ -1,0 +1,9 @@
+import pathlib
+
+
+def test_init_strategy_has_spread_check():
+    mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
+    content = mc_path.read_text(encoding="utf-8")
+    idx = content.find("bool InitStrategy()");
+    assert idx != -1, "InitStrategyが見つからない"
+    assert "SpreadExceeded" in content[idx:], "InitStrategyにスプレッド判定がない"


### PR DESCRIPTION
## 概要
- 系統Aの初期化注文前にスプレッド判定を追加
- 判定超過時のログ出力に `SpreadExceeded` を記録
- InitStrategy にスプレッド判定が存在することを確認するテストを追加

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689538bc7b708327b7a879b168b83e10