### PR TITLE
Record distance when replacing shadow order

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1040,6 +1040,7 @@ void EnsureShadowOrder(const int ticket,const string system)
          pendType  = OrderType();
          pendPrice = OrderOpenPrice();
       }
+      double distPend = MathMax(DistanceToExistingPositions(pendPrice, ticket), 0);
       int err = 0;
       ResetLastError();
       bool ok = OrderDelete(pendTicket);
@@ -1053,7 +1054,7 @@ void EnsureShadowOrder(const int ticket,const string system)
       // REFILL: 影指値の更新
       lru.Reason     = "REFILL";
       lru.Spread     = PriceToPips(Ask - Bid);
-      lru.Dist       = GridPips;
+      lru.Dist       = distPend;
       lru.GridPips   = GridPips;
       lru.s          = s;
       lru.lotFactor  = 0;


### PR DESCRIPTION
## Summary
- capture actual distance to existing positions before removing an existing shadow order
- log that distance via `LogRecord.Dist` during shadow order replacement

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895924300248327872e7677d7bff8c1