### PR TITLE
feat: add spread check before OCO reentry

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2675,6 +2675,40 @@ void HandleOCODetectionFor(const string system)
          return;
       }
       RefreshRates();
+      double spread = PriceToPips(Ask - Bid);
+      if(spread > MaxSpreadPips)
+      {
+         LogRecord lrSkip;
+         lrSkip.Time       = TimeCurrent();
+         lrSkip.Symbol     = Symbol();
+         lrSkip.System     = system;
+         lrSkip.Reason     = "REFILL";
+         lrSkip.Spread     = spread;
+         lrSkip.Dist       = MathMax(dist, 0);
+         lrSkip.GridPips   = GridPips;
+         lrSkip.s          = s;
+         lrSkip.lotFactor  = lotFactorAdj;
+         lrSkip.BaseLot    = BaseLot;
+         lrSkip.MaxLot     = MaxLot;
+         lrSkip.actualLot  = expectedLot;
+         lrSkip.seqStr     = seqAdj;
+         lrSkip.CommentTag = expectedComment;
+         lrSkip.Magic      = MagicNumber;
+         lrSkip.OrderType  = OrderTypeToStr(type);
+         lrSkip.EntryPrice = price;
+         lrSkip.SL         = slInit;
+         lrSkip.TP         = tpInit;
+         lrSkip.ErrorCode  = 0;
+         lrSkip.ErrorInfo  = "SpreadExceeded";
+         WriteLog(lrSkip);
+         PrintFormat("HandleOCODetectionFor: spread %.1f exceeds MaxSpreadPips %.1f, order skipped",
+                     spread, MaxSpreadPips);
+         if(system == "A")
+            retryTicketA = -1;
+         else
+            retryTicketB = -1;
+         return;
+      }
       ResetLastError();
       int newTicket = OrderSend(Symbol(), type, expectedLot, price,
                                 slippage, slInit, tpInit,

--- a/tests/test_handle_oco_spread_check.py
+++ b/tests/test_handle_oco_spread_check.py
@@ -1,0 +1,9 @@
+import pathlib
+
+
+def test_handle_oco_has_spread_check():
+    mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
+    content = mc_path.read_text(encoding="utf-8")
+    idx = content.find("void HandleOCODetectionFor")
+    assert idx != -1, "HandleOCODetectionForが見つからない"
+    assert "SpreadExceeded" in content[idx:], "HandleOCODetectionForにスプレッド判定がない"


### PR DESCRIPTION
## Summary
- add spread guard before reopening positions in OCO handler
- test presence of spread check in HandleOCODetectionFor

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895a121f3c083279b6a0ce776031a5f