### PR TITLE
Handle FileOpen errors in WriteLog

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -80,10 +80,16 @@ string OrderTypeToStr(const int type)
 
 void WriteLog(const LogRecord &rec)
 {
+   ResetLastError();
    int handle = FileOpen("MoveCatcher.log", FILE_CSV|FILE_WRITE|FILE_READ|FILE_APPEND);
    string timeStr = TimeToString(rec.Time, TIME_DATE|TIME_SECONDS);
    double distNorm = MathMax(rec.Dist, 0);
-   if(handle != INVALID_HANDLE)
+   if(handle == INVALID_HANDLE)
+   {
+      int err = GetLastError();
+      PrintFormat("WriteLog: FileOpen err=%d %s", err, ErrorDescription(err));
+   }
+   else
    {
       FileWrite(handle,
          timeStr,


### PR DESCRIPTION
## Summary
- guard FileOpen failures in WriteLog and report errors

## Testing
- `python3 -m pytest -q MoveCatcher-mq4/tests`


------
https://chatgpt.com/codex/tasks/task_e_6895d707b5cc832782c5da03f3645af8