### PR TITLE
Handle missing TP/SL when determining close reason

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -730,8 +730,10 @@ void ProcessClosedTrades(const string system,const bool updateDMC,const string r
         double tol        = Pip() * 0.5;
          bool isTP = (MathAbs(closePrice - OrderTakeProfit()) <= tol);
          bool isSL = (MathAbs(closePrice - OrderStopLoss())  <= tol);
-         if(isTP || isSL)
-            rsn = isTP ? "TP" : "SL";
+         bool hasTP = (OrderTakeProfit() > 0);
+         bool hasSL = (OrderStopLoss()  > 0);
+         if((hasTP && isTP) || (hasSL && isSL))
+            rsn = (hasTP && isTP) ? "TP" : "SL";
          else
          {
             string cmt = StringToUpper(OrderComment());

--- a/tests/test_close_reason.py
+++ b/tests/test_close_reason.py
@@ -7,8 +7,8 @@ def estimate_reason(order):
     close_price = order["close"]
     tp = order.get("tp", 0)
     sl = order.get("sl", 0)
-    is_tp = abs(close_price - tp) <= tol and tp != 0
-    is_sl = abs(close_price - sl) <= tol and sl != 0
+    is_tp = abs(close_price - tp) <= tol and tp > 0
+    is_sl = abs(close_price - sl) <= tol and sl > 0
     if is_tp or is_sl:
         return "TP" if is_tp else "SL"
     comment = order.get("comment", "")
@@ -39,3 +39,8 @@ def test_reason_finds_tp_sl_in_comment_case_insensitively():
     assert estimate_reason(tp_comment) == "TP"
     sl_comment = {"type": "buy", "open": 1.0, "close": 1.5, "comment": "via sl"}
     assert estimate_reason(sl_comment) == "SL"
+
+
+def test_reason_falls_back_when_tp_sl_unset_and_close_price_zero():
+    order = {"type": "buy", "open": 1.0, "close": 0.0}
+    assert estimate_reason(order) == "SL"


### PR DESCRIPTION
## Summary
- ensure ProcessClosedTrades only treats orders as TP/SL when respective levels are set
- refine close reason helper and tests to handle missing TP/SL and zero close price

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895df40f4d083278fb97c4e57953dc7