### PR TITLE
fix: refresh rates before adjusting recovery order

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1314,6 +1314,7 @@ void RecoverAfterSL(const string system)
       PrintFormat("RecoverAfterSL[%s]: failed to select reopened order for %s err=%d", flagInfo, system, lr.ErrorCode);
       return;
    }
+   RefreshRates(); // Bid と Ask を最新化
    double entry = OrderOpenPrice();
    double desiredSL = isBuy ? entry - PipsToPrice(GridPips) : entry + PipsToPrice(GridPips);
    double desiredTP = isBuy ? entry + PipsToPrice(GridPips) : entry - PipsToPrice(GridPips);


### PR DESCRIPTION
## Summary
- refresh rates before adjusting SL/TP after order recovery

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895ed6b9f5c83278650a44de92fee96