### PR TITLE
OrderSelect成功後にstate_AをAliveに設定

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2011,11 +2011,10 @@ bool InitStrategy()
       return(false);
    }
 
-   // system A 成行成立を記録
-   state_A = Alive;
-
    if(!OrderSelect(ticketA, SELECT_BY_TICKET))
       return(false);
+   // system A 成行成立を記録
+   state_A = Alive;
    double entryPrice = OrderOpenPrice();
 
    EnsureShadowOrder(ticketA, "A");


### PR DESCRIPTION
## Summary
- `InitStrategy`で`OrderSelect`が成功した場合にのみ`state_A`を`Alive`へ設定

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895f13788cc83278b01ae1046e3017c