### PR TITLE
CanPlaceOrder末尾の余計な価格丸めを削除

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -418,7 +418,6 @@ bool CanPlaceOrder(double &price,const bool isBuy,string &errorInfo,
       }
    }
 
-   price     = NormalizeDouble(price, Digits);
    errorInfo = "";
    return(true);
 }


### PR DESCRIPTION
## Summary
- CanPlaceOrderの終盤で重複していた`NormalizeDouble`呼び出しを削除し、価格を再丸めしないよう調整

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f23d45d88327bf53283fcf8bf9a2