### PR TITLE
Remove spread gating from InitStrategy market orders

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1948,36 +1948,7 @@ bool InitStrategy()
    RefreshRates();
    price = isBuy ? Ask : Bid;
 
-   double spread = PriceToPips(Ask - Bid);
-   if(spread > MaxSpreadPips)
-   {
-      LogRecord lrSkipA;
-      lrSkipA.Time       = TimeCurrent();
-      lrSkipA.Symbol     = Symbol();
-      lrSkipA.System     = "A";
-      lrSkipA.Reason     = "INIT";
-      lrSkipA.Spread     = spread;
-      lrSkipA.Dist       = MathMax(distA, 0);
-      lrSkipA.GridPips   = GridPips;
-      lrSkipA.s          = s;
-      lrSkipA.lotFactor  = lotFactorA;
-      lrSkipA.BaseLot    = BaseLot;
-      lrSkipA.MaxLot     = MaxLot;
-      lrSkipA.actualLot  = lotA;
-      lrSkipA.seqStr     = seqA;
-      lrSkipA.CommentTag = commentA;
-      lrSkipA.Magic      = MagicNumber;
-      lrSkipA.OrderType  = OrderTypeToStr(isBuy ? OP_BUY : OP_SELL);
-      lrSkipA.EntryPrice = price;
-      lrSkipA.SL         = entrySL;
-      lrSkipA.TP         = entryTP;
-      lrSkipA.ErrorCode  = 0;
-      lrSkipA.ErrorInfo  = "SpreadExceeded";
-      WriteLog(lrSkipA);
-      PrintFormat("InitStrategy: spread %.1f exceeds MaxSpreadPips %.1f, order skipped",
-                  spread, MaxSpreadPips);
-      return(false);
-   }
+   double spread = PriceToPips(Ask - Bid); // 参考情報のみ（成行では判定しない）
 
    ResetLastError();
    int ticketA = OrderSend(Symbol(), typeA, lotA, price,
@@ -1987,7 +1958,7 @@ bool InitStrategy()
    lrA.Symbol     = Symbol();
    lrA.System     = "A";
    lrA.Reason     = "INIT";
-   lrA.Spread     = PriceToPips(Ask - Bid);
+   lrA.Spread     = spread;
    lrA.Dist       = MathMax(distA, 0);
    lrA.GridPips   = GridPips;
    lrA.s          = s;

--- a/tests/test_init_strategy_spread_check.py
+++ b/tests/test_init_strategy_spread_check.py
@@ -1,9 +1,20 @@
 import pathlib
 
 
-def test_init_strategy_has_spread_check():
+def test_init_strategy_logs_spread_without_check():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     content = mc_path.read_text(encoding="utf-8")
-    idx = content.find("bool InitStrategy()");
-    assert idx != -1, "InitStrategyが見つからない"
-    assert "SpreadExceeded" in content[idx:], "InitStrategyにスプレッド判定がない"
+    lines = content.splitlines()
+    start_line = None
+    end_line = None
+    for i, line in enumerate(lines):
+        if start_line is None and line.strip() == "bool InitStrategy()":
+            start_line = i
+        elif start_line is not None and line.startswith("void HandleOCODetectionFor"):
+            end_line = i
+            break
+    assert start_line is not None, "InitStrategyが見つからない"
+    assert end_line is not None, "HandleOCODetectionForが見つからない"
+    init_body = "\n".join(lines[start_line:end_line])
+    assert "PriceToPips(Ask - Bid)" in init_body, "スプレッド取得がない"
+    assert "SpreadExceeded" not in init_body, "成行注文のスプレッド判定が残っている"


### PR DESCRIPTION
## Summary
- Drop spread check for market orders in InitStrategy
- Keep spread value for logging only
- Adjust spread-related test to expect logging without gating

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895f70f2a6083278d0c7b131cff0540