### PR TITLE
価格更新時にSL/TPを再計算するよう修正

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1945,8 +1945,43 @@ bool InitStrategy()
       return(false);
    }
    int typeA   = isBuy ? OP_BUY : OP_SELL;
+   double oldPrice = price;
    RefreshRates();
    price = isBuy ? Ask : Bid;
+   if(price != oldPrice)
+   {
+      if(isBuy)
+      {
+         entrySL = price - PipsToPrice(GridPips);
+         entryTP = price + PipsToPrice(GridPips);
+      }
+      else
+      {
+         entrySL = price + PipsToPrice(GridPips);
+         entryTP = price - PipsToPrice(GridPips);
+      }
+
+      distSL = MathAbs(price - entrySL);
+      if(distSL < minLevel)
+      {
+         double oldSL = entrySL;
+         entrySL = isBuy ? price - minLevel : price + minLevel;
+         entrySL = NormalizeDouble(entrySL, Digits);
+         PrintFormat("InitStrategy: SL adjusted from %.5f to %.5f due to min distance %.1f pips",
+                     oldSL, entrySL, PriceToPips(minLevel));
+      }
+
+      distTP = MathAbs(entryTP - price);
+      if(distTP < minLevel)
+      {
+         double oldTP = entryTP;
+         entryTP = isBuy ? price + minLevel : price - minLevel;
+         entryTP = NormalizeDouble(entryTP, Digits);
+         PrintFormat("InitStrategy: TP adjusted from %.5f to %.5f due to min distance %.1f pips",
+                     oldTP, entryTP, PriceToPips(minLevel));
+      }
+   }
+   distA = DistanceToExistingPositions(price);
 
    double spread = PriceToPips(Ask - Bid); // 参考情報のみ（成行では判定しない）
 

--- a/tests/test_recalculate_entry_levels_when_price_changes.py
+++ b/tests/test_recalculate_entry_levels_when_price_changes.py
@@ -1,0 +1,13 @@
+import pathlib
+
+
+def test_recalculate_entry_levels_when_price_changes():
+    mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
+    content = mc_path.read_text(encoding="utf-8")
+    assert "double oldPrice = price;" in content, "旧価格の保存がない"
+    assert "if(price != oldPrice)" in content, "価格変化チェックがない"
+    after = content.split("if(price != oldPrice)")[1].split("distA = DistanceToExistingPositions(price);")[0]
+    assert "entrySL = price - PipsToPrice(GridPips);" in after, "買い側のSL再計算がない"
+    assert "entrySL = price + PipsToPrice(GridPips);" in after, "売り側のSL再計算がない"
+    assert "entryTP = price + PipsToPrice(GridPips);" in after, "買い側のTP再計算がない"
+    assert "entryTP = price - PipsToPrice(GridPips);" in after, "売り側のTP再計算がない"


### PR DESCRIPTION
## 概要
- 2回目の`RefreshRates()`で価格が変わった場合、`entrySL`/`entryTP`を再計算し`GridPips`差を維持
- `InitStrategy`のログ用距離も更新
- 価格変化時にSL/TP再計算を確認するテストを追加

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f8d708d883279f287c01e21671f3