### PR TITLE
Apply slippage to SL recovery orders in both branches

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1240,7 +1240,9 @@ void RecoverAfterSL(const string system)
    }
    else
    {
-      flagInfo = "UseProtectedLimit=false slippage=0";
+      double reSlippagePips = SlippagePips;
+      slippage = (int)MathRound(reSlippagePips * Pip() / Point);
+      flagInfo = StringFormat("UseProtectedLimit=false slippage=%d", slippage);
    }
    RefreshRates();
    double price    = isBuy ? Ask : Bid;

--- a/tests/test_recover_after_sl_slippage.py
+++ b/tests/test_recover_after_sl_slippage.py
@@ -6,5 +6,6 @@ def test_recover_after_sl_slippage_toggle():
     code = mc_path.read_text(encoding="utf-8")
     assert "int    slippage = 0;" in code
     assert "if(UseProtectedLimit)" in code
-    assert "slippage = (int)MathRound(reSlippagePips * Pip() / Point);" in code
-    assert "flagInfo = \"UseProtectedLimit=false slippage=0\";" in code
+    assert code.count("slippage = (int)MathRound(reSlippagePips * Pip() / Point);") == 2
+    assert "flagInfo = StringFormat(\"UseProtectedLimit=true slippage=%d\", slippage);" in code
+    assert "flagInfo = StringFormat(\"UseProtectedLimit=false slippage=%d\", slippage);" in code


### PR DESCRIPTION
## Summary
- allow RecoverAfterSL to calculate and apply slippage from `SlippagePips` even when `UseProtectedLimit` is disabled
- adjust test to confirm slippage logic in both branches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fa434c288327a2ad9ea563039931