### PR TITLE
コメントに生数列を使用

### DIFF
--- a/include/DecompositionMonteCarloMM.mqh
+++ b/include/DecompositionMonteCarloMM.mqh
@@ -130,6 +130,18 @@ public:
    }
 
    /* デバッグ用 */
-   string Seq(){string s="";for(int i=0;i<ArraySize(seq);i++){if(i)s+=",";s+=IntegerToString(seq[i]);}return s;}
+   bool Seq(string &out,const int maxLen=15) const{
+      out="";
+      for(int i=0;i<ArraySize(seq);i++){
+         string part=IntegerToString(seq[i]);
+         int addLen=StringLen(part);
+         if(i) addLen+=1;
+         if(StringLen(out)+addLen>maxLen)
+            return(false);
+         if(i) out+=",";
+         out+=part;
+      }
+      return(true);
+   }
    int    Stock(){ return stock; }
 };

--- a/tests/test_make_comment.py
+++ b/tests/test_make_comment.py
@@ -1,28 +1,20 @@
-BASE64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-
-
 def make_comment(system: str, seq: str) -> str:
-    cleaned = seq.replace("(", "").replace(")", "").replace(" ", "")
-    parts = cleaned.split(",") if cleaned else []
-    encoded = "".join(BASE64[int(p)] for p in parts if p)
-    return f"MoveCatcher_{system}_{encoded}"
+    return f"MoveCatcher_{system}_{seq}"
 
 
 def parse_comment(comment: str):
     prefix = "MoveCatcher_"
     assert comment.startswith(prefix)
     rest = comment[len(prefix):]
-    system, enc = rest.split("_", 1)
-    numbers = [str(BASE64.index(ch)) for ch in enc]
-    seq = "(" + ",".join(numbers) + ")"
+    system, seq = rest.split("_", 1)
     return system, seq
 
 
 def test_make_comment_roundtrip():
     samples = [
         "(0,1)",
-        "(" + ",".join(str(i) for i in range(10)) + ")",
-        "(" + ",".join(str(i % 64) for i in range(17)) + ")",
+        "(" + ",".join(str(i) for i in range(8)) + ")",
+        "(10,11,12,13)",
     ]
     for seq in samples:
         for system in ['A', 'B']:


### PR DESCRIPTION
## 概要
- MakeComment/ParseComment から Base64 変換を廃止し、生の数列 `(0,1)` を埋め込む形式に変更
- DMCMM にコメント長上限を考慮した Seq 生成処理を追加し、長すぎる場合はエラー扱い
- コメント生成テストを新仕様に合わせて更新

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ffee242c8327bbfbd489ab1e168c