### PR TITLE
コメント長31文字超の切り捨て処理を廃止

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -441,7 +441,8 @@ double CalcLot(const string system,string &seq,double &lotFactor)
 
    lotFactor          = state.NextLot();
    string seqCore;
-   if(!state.Seq(seqCore))
+   const int seqMaxLen = 15;
+   if(!state.Seq(seqCore, seqMaxLen))
    {
       PrintFormat("Seq length overflow for system %s", system);
       seq="";
@@ -460,7 +461,7 @@ double CalcLot(const string system,string &seq,double &lotFactor)
       SaveDMCState(system, *state, err);
 
       lotFactor    = state.NextLot();
-      if(!state.Seq(seqCore))
+      if(!state.Seq(seqCore, seqMaxLen))
       {
          PrintFormat("Seq length overflow for system %s", system);
          seq="";
@@ -537,8 +538,6 @@ double CalcLot(const string system,string &seq,double &lotFactor)
 string MakeComment(const string system,const string seq)
 {
    string comment = StringFormat("MoveCatcher_%s_%s", system, seq);
-   if(StringLen(comment) > 31)
-      comment = StringSubstr(comment, 0, 31); // final safeguard
    return(comment);
 }
 


### PR DESCRIPTION
## 概要
- コメント生成で31文字を超える場合の切り捨てを撤廃
- DMCMM由来の数列長を明示的に15文字以内に制限し、コメント全体で31文字以内を保証

## テスト
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68960199c1d08327b0efada951718d2b