### PR TITLE
Recalculate system flags after duplicate correction

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -3045,6 +3045,30 @@ int OnInit()
    // Detect and resolve any duplicate positions before proceeding
    CorrectDuplicatePositions();
 
+   // Recalculate flags after potential corrections
+   hasAny = false;
+   hasA   = false;
+   hasB   = false;
+   for(int j = OrdersTotal() - 1; j >= 0; j--)
+   {
+      if(!OrderSelect(j, SELECT_BY_POS, MODE_TRADES))
+         continue;
+      if(OrderMagicNumber() != MagicNumber || OrderSymbol() != Symbol())
+         continue;
+      hasAny = true;
+      int t2 = OrderType();
+      string sys2, seq2;
+      if(!ParseComment(OrderComment(), sys2, seq2))
+         continue;
+      if(t2 == OP_BUY || t2 == OP_SELL)
+      {
+         if(sys2 == "A")
+            hasA = true;
+         else if(sys2 == "B")
+            hasB = true;
+      }
+   }
+
    SystemState prevA = state_A;
    SystemState prevB = state_B;
    state_A = UpdateState(prevA, hasA);

--- a/tests/test_duplicate_correction_on_init.py
+++ b/tests/test_duplicate_correction_on_init.py
@@ -14,9 +14,25 @@ def correct_duplicate_positions_py(positions):
     return list(remaining.values()), closed
 
 
-def on_init_py(positions):
-    # mimic the portion of OnInit that corrects duplicate positions
-    return correct_duplicate_positions_py(positions)
+def update_state_py(prev, exists):
+    if exists:
+        if prev == "Missing":
+            return "MissingRecovered"
+        return "Alive"
+    if prev in ("Alive", "MissingRecovered"):
+        return "Missing"
+    return "Missing" if prev == "Missing" else "None"
+
+
+def on_init_py(positions, corrector=correct_duplicate_positions_py):
+    has_a = any(p["system"] == "A" for p in positions)
+    has_b = any(p["system"] == "B" for p in positions)
+    remaining, closed = corrector(positions)
+    has_a = any(p["system"] == "A" for p in remaining)
+    has_b = any(p["system"] == "B" for p in remaining)
+    state_a = update_state_py(None, has_a)
+    state_b = update_state_py(None, has_b)
+    return remaining, closed, state_a, state_b
 
 
 def test_duplicates_resolved_on_init():
@@ -26,10 +42,27 @@ def test_duplicates_resolved_on_init():
         {"ticket": 3, "system": "B", "open_time": 1},
         {"ticket": 4, "system": "B", "open_time": 3},
     ]
-    remaining, closed = on_init_py(positions)
+    remaining, closed, _, _ = on_init_py(positions)
 
     assert len([p for p in remaining if p["system"] == "A"]) == 1
     assert len([p for p in remaining if p["system"] == "B"]) == 1
     assert {p["ticket"] for p in remaining} == {1, 3}
     assert {p["ticket"] for p in closed} == {2, 4}
+
+
+def test_states_recomputed_after_correction():
+    positions = [
+        {"ticket": 1, "system": "A", "open_time": 1},
+        {"ticket": 2, "system": "B", "open_time": 1},
+    ]
+
+    def remove_all(_):
+        return [], positions
+
+    remaining, closed, state_a, state_b = on_init_py(positions, corrector=remove_all)
+
+    assert remaining == []
+    assert closed == positions
+    assert state_a == "None"
+    assert state_b == "None"
 


### PR DESCRIPTION
## Summary
- Rescan orders after calling `CorrectDuplicatePositions` in `OnInit` to recalculate system flags and update state
- Add unit test ensuring state uses flags recomputed after duplicate correction
- Verify `OnTick` already rescans positions post-correction

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68960338a4f88327a018413ab71752ed