### PR TITLE
Avoid slippage when protected limit is disabled

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1229,9 +1229,8 @@ void RecoverAfterSL(const string system)
    }
    else
    {
-      double reSlippagePips = SlippagePips;
-      slippage = (int)MathRound(reSlippagePips * Pip() / Point);
-      flagInfo = StringFormat("UseProtectedLimit=false slippage=%d", slippage);
+      slippage = 0;         // no slippage
+      flagInfo = "UseProtectedLimit=false slippage=0";
    }
    RefreshRates();
    double price    = isBuy ? Ask : Bid;

--- a/tests/test_recover_after_sl_slippage.py
+++ b/tests/test_recover_after_sl_slippage.py
@@ -6,6 +6,7 @@ def test_recover_after_sl_slippage_toggle():
     code = mc_path.read_text(encoding="utf-8")
     assert "int    slippage = 0;" in code
     assert "if(UseProtectedLimit)" in code
-    assert code.count("slippage = (int)MathRound(reSlippagePips * Pip() / Point);") == 2
+    assert code.count("slippage = (int)MathRound(reSlippagePips * Pip() / Point);") == 1
+    assert "slippage = 0;         // no slippage" in code
     assert "flagInfo = StringFormat(\"UseProtectedLimit=true slippage=%d\", slippage);" in code
-    assert "flagInfo = StringFormat(\"UseProtectedLimit=false slippage=%d\", slippage);" in code
+    assert "flagInfo = \"UseProtectedLimit=false slippage=0\";" in code


### PR DESCRIPTION
## Summary
- Disable slippage and log explicitly when UseProtectedLimit=false
- Update tests for adjusted slippage handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689607fa96ac8327938b0216ddf5a4e7