### PR TITLE
Handle SaveDMCState failures in CalcLot

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -458,7 +458,9 @@ double CalcLot(const string system,string &seq,double &lotFactor)
    {
       state.Init();
       int err = 0;
-      SaveDMCState(system, *state, err);
+      bool ok = SaveDMCState(system, *state, err);
+      if(!ok && err != 0)
+         PrintFormat("SaveDMCState(%s) err=%d", system, err);
 
       lotFactor    = state.NextLot();
       if(!state.Seq(seqCore, seqMaxLen))


### PR DESCRIPTION
## Summary
- Log SaveDMCState failures and error codes during CalcLot

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689608f700b88327bf18040a7a298365