### PR TITLE
LOT_RESET ログで ErrorInfo に ErrorDescription を設定

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -494,7 +494,7 @@ double CalcLot(const string system,string &seq,double &lotFactor)
          lr.SL         = 0;
          lr.TP         = 0;
          lr.ErrorCode  = err;
-         lr.ErrorInfo  = (err != 0) ? ErrorDescription(err) : "";
+         lr.ErrorInfo  = ErrorDescription(err);
          WriteLog(lr);
          return(0.0);
       }
@@ -524,7 +524,7 @@ double CalcLot(const string system,string &seq,double &lotFactor)
       lr.SL         = 0;
       lr.TP         = 0;
       lr.ErrorCode  = err;
-      lr.ErrorInfo  = (err != 0) ? ErrorDescription(err) : "";
+      lr.ErrorInfo  = ErrorDescription(err);
       WriteLog(lr);
 
       return(lotActual);


### PR DESCRIPTION
## Summary
- LOT_RESET ログで常にエラー説明を出力

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689613a71c4083278f19d3d06a719132