### PR TITLE
InitStrategyで価格更新後も距離帯を再検証

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1980,6 +1980,35 @@ bool InitStrategy()
       }
    }
    distA = DistanceToExistingPositions(price);
+   if(UseDistanceBand && distA >= 0 && (distA < MinDistancePips || distA > MaxDistancePips))
+   {
+      LogRecord lrSkipA;
+      lrSkipA.Time       = TimeCurrent();
+      lrSkipA.Symbol     = Symbol();
+      lrSkipA.System     = "A";
+      lrSkipA.Reason     = "INIT";
+      lrSkipA.Spread     = PriceToPips(Ask - Bid);
+      lrSkipA.Dist       = MathMax(distA, 0);
+      lrSkipA.GridPips   = GridPips;
+      lrSkipA.s          = s;
+      lrSkipA.lotFactor  = lotFactorA;
+      lrSkipA.BaseLot    = BaseLot;
+      lrSkipA.MaxLot     = MaxLot;
+      lrSkipA.actualLot  = lotA;
+      lrSkipA.seqStr     = seqA;
+      lrSkipA.CommentTag = commentA;
+      lrSkipA.Magic      = MagicNumber;
+      lrSkipA.OrderType  = OrderTypeToStr(isBuy ? OP_BUY : OP_SELL);
+      lrSkipA.EntryPrice = price;
+      lrSkipA.SL         = entrySL;
+      lrSkipA.TP         = entryTP;
+      lrSkipA.ErrorCode  = 0;
+      lrSkipA.ErrorInfo  = "Distance band violation";
+      WriteLog(lrSkipA);
+      PrintFormat("InitStrategy: distance %.1f outside band [%.1f, %.1f], order skipped",
+                  distA, MinDistancePips, MaxDistancePips);
+      return(false);
+   }
 
    double spread = PriceToPips(Ask - Bid); // 参考情報のみ（成行では判定しない）
 

--- a/tests/test_init_strategy_distance_band_recheck.py
+++ b/tests/test_init_strategy_distance_band_recheck.py
@@ -1,0 +1,28 @@
+import pathlib
+
+
+def test_init_strategy_rechecks_distance_band_after_price_refresh():
+    mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
+    content = mc_path.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    start_line = None
+    end_line = None
+    for i, line in enumerate(lines):
+        if start_line is None and line.strip() == "bool InitStrategy()":
+            start_line = i
+        elif start_line is not None and line.startswith("void HandleOCODetectionFor"):
+            end_line = i
+            break
+    assert start_line is not None, "InitStrategyが見つからない"
+    assert end_line is not None, "HandleOCODetectionForが見つからない"
+    init_body = lines[start_line:end_line]
+    body_text = "\n".join(init_body)
+    assert body_text.count("UseDistanceBand && distA >= 0") >= 2, "距離帯チェックが2回行われていない"
+    refresh_idx = None
+    for i, line in enumerate(init_body):
+        if "RefreshRates();" in line:
+            refresh_idx = i
+            break
+    assert refresh_idx is not None, "RefreshRatesが見つからない"
+    post_refresh = "\n".join(init_body[refresh_idx:])
+    assert "UseDistanceBand && distA >= 0" in post_refresh, "価格更新後の距離帯チェックが不足"


### PR DESCRIPTION
## Summary
- RefreshRates後に距離帯を再チェックし、帯外なら発注を中止してログを記録
- InitStrategyが2回距離帯を判定することを確認するテストを追加

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896187532f48327918d908022bc17d7