### PR TITLE
OCO検出でのスプレッド判定を無効化

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2729,39 +2729,6 @@ void HandleOCODetectionFor(const string system)
       }
       RefreshRates();
       double spread = PriceToPips(Ask - Bid);
-      if(spread > MaxSpreadPips)
-      {
-         LogRecord lrSkip;
-         lrSkip.Time       = TimeCurrent();
-         lrSkip.Symbol     = Symbol();
-         lrSkip.System     = system;
-         lrSkip.Reason     = "REFILL";
-         lrSkip.Spread     = spread;
-         lrSkip.Dist       = MathMax(dist, 0);
-         lrSkip.GridPips   = GridPips;
-         lrSkip.s          = s;
-         lrSkip.lotFactor  = lotFactorAdj;
-         lrSkip.BaseLot    = BaseLot;
-         lrSkip.MaxLot     = MaxLot;
-         lrSkip.actualLot  = expectedLot;
-         lrSkip.seqStr     = seqAdj;
-         lrSkip.CommentTag = expectedComment;
-         lrSkip.Magic      = MagicNumber;
-         lrSkip.OrderType  = OrderTypeToStr(type);
-         lrSkip.EntryPrice = price;
-         lrSkip.SL         = slInit;
-         lrSkip.TP         = tpInit;
-         lrSkip.ErrorCode  = 0;
-         lrSkip.ErrorInfo  = "SpreadExceeded";
-         WriteLog(lrSkip);
-         PrintFormat("HandleOCODetectionFor: spread %.1f exceeds MaxSpreadPips %.1f, order skipped",
-                     spread, MaxSpreadPips);
-         if(system == "A")
-            retryTicketA = -1;
-         else
-            retryTicketB = -1;
-         return;
-      }
       ResetLastError();
       int newTicket = OrderSend(Symbol(), type, expectedLot, price,
                                 slippage, slInit, tpInit,
@@ -2774,7 +2741,7 @@ void HandleOCODetectionFor(const string system)
          lrFail.Symbol     = Symbol();
          lrFail.System     = system;
          lrFail.Reason     = "REFILL";
-         lrFail.Spread     = PriceToPips(Ask - Bid);
+         lrFail.Spread     = spread;
          lrFail.Dist       = MathMax(dist, 0);
          lrFail.GridPips   = GridPips;
          lrFail.s          = s;

--- a/tests/test_handle_oco_spread_check.py
+++ b/tests/test_handle_oco_spread_check.py
@@ -1,9 +1,9 @@
 import pathlib
 
 
-def test_handle_oco_has_spread_check():
+def test_handle_oco_spread_check_removed():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     content = mc_path.read_text(encoding="utf-8")
     idx = content.find("void HandleOCODetectionFor")
     assert idx != -1, "HandleOCODetectionForが見つからない"
-    assert "SpreadExceeded" in content[idx:], "HandleOCODetectionForにスプレッド判定がない"
+    assert "SpreadExceeded" not in content[idx:], "HandleOCODetectionForにスプレッド判定が残っている"


### PR DESCRIPTION
## Summary
- HandleOCODetectionForからMaxSpreadPipsによるスキップ処理を削除し、スプレッドはログのみ記録
- テストを修正し、スプレッド判定が存在しないことを検証

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961fe8d00c8327a46987d1b87a9d73