### PR TITLE
HandleOCODetectionForの距離帯判定を除去

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2595,38 +2595,6 @@ void HandleOCODetectionFor(const string system)
       RefreshRates();
       double price = (type == OP_BUY) ? Ask : Bid;
       double dist = DistanceToExistingPositions(price);
-      if(UseDistanceBand && dist >= 0 && (dist < MinDistancePips || dist > MaxDistancePips))
-      {
-         LogRecord lrSkip;
-         lrSkip.Time       = TimeCurrent();
-         lrSkip.Symbol     = Symbol();
-         lrSkip.System     = system;
-        lrSkip.Reason     = "REFILL";
-        lrSkip.Spread     = PriceToPips(Ask - Bid);
-        lrSkip.Dist       = MathMax(dist, 0);
-         lrSkip.GridPips   = GridPips;
-         lrSkip.s          = s;
-         lrSkip.lotFactor  = lotFactorAdj;
-         lrSkip.BaseLot    = BaseLot;
-         lrSkip.MaxLot     = MaxLot;
-         lrSkip.actualLot  = expectedLot;
-         lrSkip.seqStr     = seqAdj;
-         lrSkip.CommentTag = expectedComment;
-         lrSkip.Magic      = MagicNumber;
-         lrSkip.OrderType  = OrderTypeToStr(type);
-         lrSkip.EntryPrice = price;
-         lrSkip.SL         = 0;
-         lrSkip.TP         = 0;
-         lrSkip.ErrorCode  = 0;
-         WriteLog(lrSkip);
-         PrintFormat("HandleOCODetectionFor: distance %.1f outside band [%.1f, %.1f], order skipped",
-                     dist, MinDistancePips, MaxDistancePips);
-         if(system == "A")
-            retryTicketA = -1;
-         else
-            retryTicketB = -1;
-         return;
-      }
       slippage = (int)MathRound(SlippagePips * Pip() / Point);
       double slInit, tpInit;
       if(type == OP_BUY)

--- a/tests/test_handle_oco_distance_band_removed.py
+++ b/tests/test_handle_oco_distance_band_removed.py
@@ -1,0 +1,14 @@
+import pathlib
+
+
+def test_handle_oco_distance_band_removed():
+    mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
+    content = mc_path.read_text(encoding="utf-8")
+    idx = content.find("void HandleOCODetectionFor")
+    assert idx != -1, "HandleOCODetectionForが見つからない"
+    end_idx = content.find("\nvoid ", idx + 1)
+    if end_idx == -1:
+        end_idx = len(content)
+    fragment = content[idx:end_idx]
+    assert "UseDistanceBand" not in fragment, "HandleOCODetectionForに距離帯判定が残っている"
+    assert "outside band" not in fragment, "距離帯スキップのログが残っている"


### PR DESCRIPTION
## 概要
- HandleOCODetectionFor内の距離帯判定(UseDistanceBand)を撤去
- 距離帯スキップログを削除し、テストを追加

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896212e3e448327b4d8642b87009543