### PR TITLE
Check spread and distance band before refill order

### DIFF
--- a/tests/test_handle_oco_can_place_order.py
+++ b/tests/test_handle_oco_can_place_order.py
@@ -1,0 +1,9 @@
+import pathlib
+import re
+
+
+def test_handle_oco_uses_can_place_order():
+    mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
+    content = mc_path.read_text(encoding="utf-8")
+    pattern = r"CanPlaceOrder\s*\(\s*price\s*,\s*\(type == OP_BUY\)\s*,\s*errcp\s*\)"
+    assert re.search(pattern, content), "HandleOCODetectionFor で CanPlaceOrder 呼び出しが必要"

--- a/tests/test_handle_oco_distance_band_removed.py
+++ b/tests/test_handle_oco_distance_band_removed.py
@@ -1,7 +1,7 @@
 import pathlib
 
 
-def test_handle_oco_distance_band_removed():
+def test_handle_oco_distance_band_violation_logging():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     content = mc_path.read_text(encoding="utf-8")
     idx = content.find("void HandleOCODetectionFor")
@@ -10,5 +10,4 @@ def test_handle_oco_distance_band_removed():
     if end_idx == -1:
         end_idx = len(content)
     fragment = content[idx:end_idx]
-    assert "UseDistanceBand" not in fragment, "HandleOCODetectionForに距離帯判定が残っている"
-    assert "outside band" not in fragment, "距離帯スキップのログが残っている"
+    assert "DistanceBandViolation" in fragment, "距離帯判定エラーのハンドリングが必要"

--- a/tests/test_handle_oco_spread_check.py
+++ b/tests/test_handle_oco_spread_check.py
@@ -1,9 +1,9 @@
 import pathlib
 
 
-def test_handle_oco_spread_check_removed():
+def test_handle_oco_spread_check_present():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     content = mc_path.read_text(encoding="utf-8")
     idx = content.find("void HandleOCODetectionFor")
     assert idx != -1, "HandleOCODetectionForが見つからない"
-    assert "SpreadExceeded" not in content[idx:], "HandleOCODetectionForにスプレッド判定が残っている"
+    assert "SpreadExceeded" in content[idx:], "HandleOCODetectionForにスプレッド判定が必要"


### PR DESCRIPTION
## Summary
- Ensure CanPlaceOrder validates spread and distance band before reopening positions
- Skip refill orders and log cause when spread or distance checks fail
- Extend CanPlaceOrder to handle market-price checks and add tests for new behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68963336b85883278a60f2de3ccf8035