### PR TITLE
Apply slippage calculation consistently after SL

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1254,8 +1254,8 @@ void DeletePendings(const string system,const string reason)
 }
 
 //+------------------------------------------------------------------+
-//| Re-enter position after SL. SlippagePips is applied only when     |
-//| UseProtectedLimit is true.                                        |
+//| Re-enter position after SL. SlippagePips is always used to compute |
+//| slippage regardless of UseProtectedLimit.                         |
 //+------------------------------------------------------------------+
 void RecoverAfterSL(const string system)
 {
@@ -1292,19 +1292,13 @@ void RecoverAfterSL(const string system)
       return;
 
    bool   isBuy    = (lastType == OP_BUY);
-   int    slippage = 0;
+   double reSlippagePips = SlippagePips;
+   int    slippage = (int)MathRound(reSlippagePips * Pip() / Point);
    string flagInfo;
    if(UseProtectedLimit)
-   {
-      double reSlippagePips = SlippagePips;
-      slippage = (int)MathRound(reSlippagePips * Pip() / Point);
       flagInfo = StringFormat("UseProtectedLimit=true slippage=%d", slippage);
-   }
    else
-   {
-      slippage = 0;         // no slippage
-      flagInfo = "UseProtectedLimit=false slippage=0";
-   }
+      flagInfo = StringFormat("UseProtectedLimit=false slippage=%d", slippage);
    RefreshRates();
    double price    = isBuy ? Ask : Bid;
    price           = NormalizeDouble(price, Digits);

--- a/tests/test_recover_after_sl_slippage.py
+++ b/tests/test_recover_after_sl_slippage.py
@@ -4,9 +4,8 @@ import pathlib
 def test_recover_after_sl_slippage_toggle():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     code = mc_path.read_text(encoding="utf-8")
-    assert "int    slippage = 0;" in code
+    assert "double reSlippagePips = SlippagePips;" in code
+    assert "int    slippage = (int)MathRound(reSlippagePips * Pip() / Point);" in code
     assert "if(UseProtectedLimit)" in code
-    assert code.count("slippage = (int)MathRound(reSlippagePips * Pip() / Point);") == 1
-    assert "slippage = 0;         // no slippage" in code
     assert "flagInfo = StringFormat(\"UseProtectedLimit=true slippage=%d\", slippage);" in code
-    assert "flagInfo = \"UseProtectedLimit=false slippage=0\";" in code
+    assert "flagInfo = StringFormat(\"UseProtectedLimit=false slippage=%d\", slippage);" in code


### PR DESCRIPTION
## Summary
- Always compute slippage using SlippagePips in RecoverAfterSL
- Include actual slippage in flagInfo regardless of UseProtectedLimit
- Update tests for new slippage handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896356e961c8327a2e6f7e545c4b530