### PR TITLE
Handle slippage with protected limit disabled

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1293,11 +1293,10 @@ void RecoverAfterSL(const string system)
    bool   isBuy    = (lastType == OP_BUY);
    double reSlippagePips = SlippagePips;
    int    slippage = (int)MathRound(reSlippagePips * Pip() / Point);
-   string flagInfo;
-   if(UseProtectedLimit)
-      flagInfo = StringFormat("UseProtectedLimit=true slippage=%d", slippage);
-   else
-      flagInfo = StringFormat("UseProtectedLimit=false slippage=%d", slippage);
+   if(!UseProtectedLimit)
+      slippage = 0;
+   string flagInfo = StringFormat("UseProtectedLimit=%s slippage=%d",
+                                  UseProtectedLimit ? "true" : "false", slippage);
    RefreshRates();
    double price    = isBuy ? Ask : Bid;
    price           = NormalizeDouble(price, Digits);

--- a/tests/test_recover_after_sl_slippage.py
+++ b/tests/test_recover_after_sl_slippage.py
@@ -6,6 +6,7 @@ def test_recover_after_sl_slippage_toggle():
     code = mc_path.read_text(encoding="utf-8")
     assert "double reSlippagePips = SlippagePips;" in code
     assert "int    slippage = (int)MathRound(reSlippagePips * Pip() / Point);" in code
-    assert "if(UseProtectedLimit)" in code
-    assert "flagInfo = StringFormat(\"UseProtectedLimit=true slippage=%d\", slippage);" in code
-    assert "flagInfo = StringFormat(\"UseProtectedLimit=false slippage=%d\", slippage);" in code
+    assert "if(!UseProtectedLimit)" in code
+    assert "slippage = 0;" in code
+    assert "StringFormat(\"UseProtectedLimit=%s slippage=%d\"" in code
+    assert "UseProtectedLimit ? \"true\" : \"false\"" in code


### PR DESCRIPTION
## Summary
- Set slippage to zero when UseProtectedLimit is false during RecoverAfterSL
- Update slippage test expectations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68963f19f82c83278a89d88239352f9b