### PR TITLE
RefreshRatesの戻り値を検証する

### DIFF
--- a/tests/test_init_strategy_distance_band_recheck.py
+++ b/tests/test_init_strategy_distance_band_recheck.py
@@ -20,7 +20,7 @@ def test_init_strategy_rechecks_distance_band_after_price_refresh():
     assert body_text.count("UseDistanceBand && distA >= 0") >= 2, "距離帯チェックが2回行われていない"
     refresh_idx = None
     for i, line in enumerate(init_body):
-        if "RefreshRates();" in line:
+        if "RefreshRates" in line:
             refresh_idx = i
             break
     assert refresh_idx is not None, "RefreshRatesが見つからない"


### PR DESCRIPTION
## Summary
- RefreshRates() をラップした RefreshRatesChecked を追加し、全体で失敗時にログを出して処理を停止
- InitStrategy の距離帯再チェックテストを RefreshRatesChecked 対応に更新

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689643b42dd88327a691f639f0d68645