### PR TITLE
Always apply slippage after SL recovery

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1355,9 +1355,7 @@ void RecoverAfterSL(const string system)
 
    bool   isBuy    = (lastType == OP_BUY);
    double reSlippagePips = SlippagePips;
-   int    slippage = (int)MathRound(reSlippagePips * Pip() / Point);
-   if(!UseProtectedLimit)
-      slippage = 0;
+   int    slippage = (int)MathRound(reSlippagePips * Pip() / Point); // always apply SlippagePips (UseProtectedLimit only toggles protection)
    string flagInfo = StringFormat("UseProtectedLimit=%s slippage=%d",
                                   UseProtectedLimit ? "true" : "false", slippage);
    if(!RefreshRatesChecked(__FUNCTION__))

--- a/tests/test_recover_after_sl_slippage.py
+++ b/tests/test_recover_after_sl_slippage.py
@@ -1,12 +1,12 @@
 import pathlib
 
 
-def test_recover_after_sl_slippage_toggle():
+def test_recover_after_sl_slippage_always_applied():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     code = mc_path.read_text(encoding="utf-8")
     assert "double reSlippagePips = SlippagePips;" in code
     assert "int    slippage = (int)MathRound(reSlippagePips * Pip() / Point);" in code
-    assert "if(!UseProtectedLimit)" in code
-    assert "slippage = 0;" in code
+    assert "if(!UseProtectedLimit)" not in code
+    assert "slippage = 0;" not in code
     assert "StringFormat(\"UseProtectedLimit=%s slippage=%d\"" in code
     assert "UseProtectedLimit ? \"true\" : \"false\"" in code


### PR DESCRIPTION
## Summary
- Ensure stop-loss recovery always uses configured slippage pips
- Update tests to reflect unconditional slippage usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964861bc2c8327aa6166e43feb5f83