### PR TITLE
Ensure comments comply with MT4 length limit

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -625,7 +625,14 @@ double CalcLot(const string system,string &seq,double &lotFactor)
 //+------------------------------------------------------------------+
 string MakeComment(const string system,const string seq)
 {
+   const int MAX_COMMENT_LENGTH = 31;
    string comment = StringFormat("MoveCatcher_%s_%s", system, seq);
+   int len = StringLen(comment);
+   if(len > MAX_COMMENT_LENGTH)
+   {
+      PrintFormat("MakeComment: comment '%s' length %d exceeds %d, truncating", comment, len, MAX_COMMENT_LENGTH);
+      comment = StringSubstr(comment, 0, MAX_COMMENT_LENGTH);
+   }
    return(comment);
 }
 

--- a/tests/test_make_comment.py
+++ b/tests/test_make_comment.py
@@ -1,5 +1,11 @@
+MAX_COMMENT_LENGTH = 31
+
+
 def make_comment(system: str, seq: str) -> str:
-    return f"MoveCatcher_{system}_{seq}"
+    comment = f"MoveCatcher_{system}_{seq}"
+    if len(comment) > MAX_COMMENT_LENGTH:
+        comment = comment[:MAX_COMMENT_LENGTH]
+    return comment
 
 
 def parse_comment(comment: str):
@@ -19,8 +25,17 @@ def test_make_comment_roundtrip():
     for seq in samples:
         for system in ['A', 'B']:
             comment = make_comment(system, seq)
-            assert len(comment) <= 31
+            assert len(comment) <= MAX_COMMENT_LENGTH
             sys, dec = parse_comment(comment)
             assert sys == system
             assert dec == seq
+
+
+def test_make_comment_truncates_long_seq():
+    seq = "(" + ",".join(str(i) for i in range(20)) + ")"
+    comment = make_comment('A', seq)
+    assert len(comment) == MAX_COMMENT_LENGTH
+    sys, dec = parse_comment(comment)
+    assert sys == 'A'
+    assert comment == f"MoveCatcher_{sys}_{dec}"
 


### PR DESCRIPTION
## Summary
- Trim generated order comments to 31 characters and log when truncation occurs
- Add tests to confirm comment strings never exceed the MT4 limit and truncate long sequences

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68964a9c32ac8327ad1b7cfa41a43783