### PR TITLE
Simplify user MaxLot clipping in CalcLot

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -583,7 +583,6 @@ double CalcLot(const string system,string &seq,double &lotFactor)
          return(0.0);
       }
       lotCandidate = BaseLot * lotFactor;
-      lotCandidate = MathMin(lotCandidate, MaxLot);
       double lotActual = NormalizeLot(lotCandidate);
       lotActual = ClipToUserMax(lotActual);
 
@@ -614,7 +613,6 @@ double CalcLot(const string system,string &seq,double &lotFactor)
       return(lotActual);
    }
 
-   lotCandidate = MathMin(lotCandidate, MaxLot);
    double lotActual = NormalizeLot(lotCandidate);
    lotActual = ClipToUserMax(lotActual);
    return(lotActual);

--- a/tests/test_lot_limits.py
+++ b/tests/test_lot_limits.py
@@ -31,8 +31,13 @@ def clip_to_user_max(lot: float, user_max: float, lot_step: float) -> float:
     return round(result, lot_digits)
 
 
-def calc_lot(lot_candidate: float, user_max: float, min_lot: float, max_lot_broker: float, lot_step: float) -> float:
-    lot_candidate = min(lot_candidate, user_max)
+def calc_lot(
+    lot_candidate: float,
+    user_max: float,
+    min_lot: float,
+    max_lot_broker: float,
+    lot_step: float,
+) -> float:
     lot_actual = normalize_lot(lot_candidate, min_lot, max_lot_broker, lot_step)
     lot_actual = clip_to_user_max(lot_actual, user_max, lot_step)
     return lot_actual


### PR DESCRIPTION
## Summary
- unify CalcLot lot-limit handling by removing pre-normalization MathMin
- adjust unit test calc_lot to match new logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68964bb67040832794ef8ead7a6f4901