### PR TITLE
Suppress error info logging on success in CalcLot

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -532,7 +532,10 @@ double CalcLot(const string system,string &seq,double &lotFactor)
       lr.SL         = 0;
       lr.TP         = 0;
       lr.ErrorCode  = err;
-      lr.ErrorInfo  = ErrorDescription(err);
+      if(err == 0)
+         lr.ErrorInfo  = "";
+      else
+         lr.ErrorInfo  = ErrorDescription(err);
       WriteLog(lr);
 
       return(0.0);
@@ -578,7 +581,10 @@ double CalcLot(const string system,string &seq,double &lotFactor)
          lr.SL         = 0;
          lr.TP         = 0;
          lr.ErrorCode  = err;
-         lr.ErrorInfo  = ErrorDescription(err);
+         if(err == 0)
+            lr.ErrorInfo  = "";
+         else
+            lr.ErrorInfo  = ErrorDescription(err);
          WriteLog(lr);
          return(0.0);
       }
@@ -607,7 +613,10 @@ double CalcLot(const string system,string &seq,double &lotFactor)
       lr.SL         = 0;
       lr.TP         = 0;
       lr.ErrorCode  = err;
-      lr.ErrorInfo  = ErrorDescription(err);
+      if(err == 0)
+         lr.ErrorInfo  = "";
+      else
+         lr.ErrorInfo  = ErrorDescription(err);
       WriteLog(lr);
 
       return(lotActual);


### PR DESCRIPTION
## Summary
- Clear `ErrorInfo` when `CalcLot` log records have no errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964e19bf708327997e216f787e68e4