### PR TITLE
Enable spread check for shadow orders

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1121,7 +1121,7 @@ void EnsureShadowOrder(const int ticket,const string system)
       return;
 
    string errcp = "";
-   bool   canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, false, ticket, false);
+   bool   canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, true, ticket, false);
    double distBand = MathMax(DistanceToExistingPositions(price, ticket), 0);
    if(!canPlace)
    {
@@ -1146,17 +1146,23 @@ void EnsureShadowOrder(const int ticket,const string system)
       lre.SL         = 0;
       lre.TP         = 0;
       int errCode = 0;
+      string errMsg = errcp;
       if(errcp == "FreezeLevel violation")
          errCode = ERR_INVALID_STOPS;
       else if(errcp == "Wrong direction")
          errCode = ERR_INVALID_PRICE;
+      else if(errcp == "SpreadExceeded")
+      {
+         errCode = ERR_SPREAD_EXCEEDED;
+         errMsg  = "Spread exceeded";
+      }
       lre.ErrorCode  = errCode;
-      lre.ErrorInfo  = hasPend ? errcp + " (existing order kept)" : errcp;
+      lre.ErrorInfo  = hasPend ? errMsg + " (existing order kept)" : errMsg;
       WriteLog(lre);
       if(hasPend)
-         PrintFormat("EnsureShadowOrder: %s - keeping existing shadow order for %s", errcp, system);
+         PrintFormat("EnsureShadowOrder: %s - keeping existing shadow order for %s", errMsg, system);
       else
-         PrintFormat("EnsureShadowOrder: %s - will retry for %s", errcp, system);
+         PrintFormat("EnsureShadowOrder: %s - will retry for %s", errMsg, system);
 
       if(system == "A")
          shadowRetryA = true;

--- a/tests/test_shadow_order_distance_band.py
+++ b/tests/test_shadow_order_distance_band.py
@@ -5,5 +5,5 @@ import re
 def test_shadow_order_respects_distance_band():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     content = mc_path.read_text(encoding="utf-8")
-    pattern = r"CanPlaceOrder\s*\(\s*price\s*,\s*\(type == OP_BUYLIMIT\)\s*,\s*errcp\s*,\s*false\s*,\s*ticket\s*,\s*false\s*\)"
+    pattern = r"CanPlaceOrder\s*\(\s*price\s*,\s*\(type == OP_BUYLIMIT\)\s*,\s*errcp\s*,\s*true\s*,\s*ticket\s*,\s*false\s*\)"
     assert re.search(pattern, content), "影指値では距離帯判定を行わない"


### PR DESCRIPTION
## Summary
- ensure shadow orders honor spread limits by enabling CanPlaceOrder check
- log "Spread exceeded" with ERR_SPREAD_EXCEEDED when placement fails
- adjust test to reflect spread checking on shadow orders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689651c4b55c83278c66aff67b006080