### PR TITLE
コメント短縮処理とトレーサビリティ強化

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -637,8 +637,16 @@ string MakeComment(const string system,const string seq)
    int len = StringLen(comment);
    if(len > MAX_COMMENT_LENGTH)
    {
-      PrintFormat("MakeComment: comment '%s' length %d exceeds %d, truncating", comment, len, MAX_COMMENT_LENGTH);
-      comment = StringSubstr(comment, 0, MAX_COMMENT_LENGTH);
+      string prefix = StringFormat("MoveCatcher_%s_", system);
+      int tailLen = MAX_COMMENT_LENGTH - StringLen(prefix) - 3;
+      if(tailLen < 0) tailLen = 0;
+      int seqLen = StringLen(seq);
+      int tailStart = seqLen - tailLen;
+      if(tailStart < 0) tailStart = 0;
+      string tail = StringSubstr(seq, tailStart);
+      string truncated = prefix + "..." + tail;
+      PrintFormat("MakeComment: comment '%s' length %d exceeds %d, truncated to '%s'", comment, len, MAX_COMMENT_LENGTH, truncated);
+      comment = truncated;
    }
    return(comment);
 }

--- a/tests/test_make_comment.py
+++ b/tests/test_make_comment.py
@@ -4,7 +4,10 @@ MAX_COMMENT_LENGTH = 31
 def make_comment(system: str, seq: str) -> str:
     comment = f"MoveCatcher_{system}_{seq}"
     if len(comment) > MAX_COMMENT_LENGTH:
-        comment = comment[:MAX_COMMENT_LENGTH]
+        prefix = f"MoveCatcher_{system}_"
+        tail_len = MAX_COMMENT_LENGTH - len(prefix) - 3
+        tail = seq[-tail_len:] if tail_len > 0 else ""
+        comment = f"{prefix}...{tail}"
     return comment
 
 
@@ -34,8 +37,11 @@ def test_make_comment_roundtrip():
 def test_make_comment_truncates_long_seq():
     seq = "(" + ",".join(str(i) for i in range(20)) + ")"
     comment = make_comment('A', seq)
-    assert len(comment) == MAX_COMMENT_LENGTH
+    assert len(comment) <= MAX_COMMENT_LENGTH
     sys, dec = parse_comment(comment)
     assert sys == 'A'
+    tail_len = MAX_COMMENT_LENGTH - len(f"MoveCatcher_{sys}_") - 3
+    assert dec.startswith("...")
+    assert dec.endswith(seq[-tail_len:])
     assert comment == f"MoveCatcher_{sys}_{dec}"
 


### PR DESCRIPTION
## Summary
- コメントが31文字を超える場合にプレフィックスと末尾を保持しつつ`...`で省略
- 省略が発生した際に元のコメントと省略後のコメントをログ出力
- 長いシーケンスでもコメント解析が可能なことをテストで確認

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68966da8bb1c8327a7a20e5660153b07