### PR TITLE
影指値のスプレッド判定を無効化

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1129,7 +1129,7 @@ void EnsureShadowOrder(const int ticket,const string system)
       return;
 
    string errcp = "";
-   bool   canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, true, ticket, false);
+   bool   canPlace = CanPlaceOrder(price, (type == OP_BUYLIMIT), errcp, false, ticket, false);
    double distBand = MathMax(DistanceToExistingPositions(price, ticket), 0);
    if(!canPlace)
    {
@@ -1159,11 +1159,6 @@ void EnsureShadowOrder(const int ticket,const string system)
          errCode = ERR_INVALID_STOPS;
       else if(errcp == "Wrong direction")
          errCode = ERR_INVALID_PRICE;
-      else if(errcp == "SpreadExceeded")
-      {
-         errCode = ERR_SPREAD_EXCEEDED;
-         errMsg  = "Spread exceeded";
-      }
       lre.ErrorCode  = errCode;
       lre.ErrorInfo  = hasPend ? errMsg + " (existing order kept)" : errMsg;
       WriteLog(lre);

--- a/tests/test_shadow_order_distance_band.py
+++ b/tests/test_shadow_order_distance_band.py
@@ -5,5 +5,5 @@ import re
 def test_shadow_order_respects_distance_band():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     content = mc_path.read_text(encoding="utf-8")
-    pattern = r"CanPlaceOrder\s*\(\s*price\s*,\s*\(type == OP_BUYLIMIT\)\s*,\s*errcp\s*,\s*true\s*,\s*ticket\s*,\s*false\s*\)"
-    assert re.search(pattern, content), "影指値では距離帯判定を行わない"
+    pattern = r"CanPlaceOrder\s*\(\s*price\s*,\s*\(type == OP_BUYLIMIT\)\s*,\s*errcp\s*,\s*false\s*,\s*ticket\s*,\s*false\s*\)"
+    assert re.search(pattern, content), "影指値ではスプレッドおよび距離帯判定を行わない"


### PR DESCRIPTION
## Summary
- 影指値注文で CanPlaceOrder を呼び出す際にスプレッド判定を無効化
- スプレッド超過エラー処理を削除し、ログにはスプレッド値のみ記録
- テストを修正して新しい呼び出しシグネチャを検証

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68968983a6a083279a09e7f55b2c2743