### PR TITLE
fix: log SaveDMCState errors

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -3805,7 +3805,7 @@ void OnDeinit(const int reason)
    bool savedA = SaveDMCState("A", stateA, err);
    if(!savedA)
    {
-      PrintFormat("SaveDMCState(%s) err=%d", "A", err);
+      PrintFormat("SaveDMCState(%s) err=%d %s", "A", err, ErrorDescription(err));
       LogRecord lr;
       lr.Time       = TimeCurrent();
       lr.Symbol     = Symbol();
@@ -3827,7 +3827,7 @@ void OnDeinit(const int reason)
       lr.SL         = 0;
       lr.TP         = 0;
       lr.ErrorCode  = err;
-      lr.ErrorInfo  = "";
+      lr.ErrorInfo  = ErrorDescription(err);
       WriteLog(lr);
    }
 
@@ -3835,7 +3835,7 @@ void OnDeinit(const int reason)
    bool savedB = SaveDMCState("B", stateB, err);
    if(!savedB)
    {
-      PrintFormat("SaveDMCState(%s) err=%d", "B", err);
+      PrintFormat("SaveDMCState(%s) err=%d %s", "B", err, ErrorDescription(err));
       LogRecord lr;
       lr.Time       = TimeCurrent();
       lr.Symbol     = Symbol();
@@ -3857,7 +3857,7 @@ void OnDeinit(const int reason)
       lr.SL         = 0;
       lr.TP         = 0;
       lr.ErrorCode  = err;
-      lr.ErrorInfo  = "";
+      lr.ErrorInfo  = ErrorDescription(err);
       WriteLog(lr);
    }
 }


### PR DESCRIPTION
## Summary
- SaveDMCState失敗時にエラーコードと説明をコンソールおよびログへ出力
- stateA/B両方でlr.ErrorInfoへErrorDescriptionを設定

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68968e71b7148327864b9ac421fc0344