### PR TITLE
Skip CanPlaceOrder on market reentry

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2791,15 +2791,17 @@ void HandleOCODetectionFor(const string system)
          WriteLog(lrFail);
          return;
       }
-      string errcp;
-      if(!CanPlaceOrder(price, (retryType == OP_BUY), errcp))
+      if(!RefreshRatesChecked(__FUNCTION__))
+         return;
+      double spread = PriceToPips(MathAbs(Ask - Bid));
+      if(MaxSpreadPips > 0 && spread > MaxSpreadPips)
       {
          LogRecord lrFail;
          lrFail.Time       = TimeCurrent();
          lrFail.Symbol     = Symbol();
          lrFail.System     = system;
          lrFail.Reason     = "REFILL";
-         lrFail.Spread     = PriceToPips(MathAbs(Ask - Bid));
+         lrFail.Spread     = spread;
          lrFail.Dist       = MathMax(dist, 0);
          lrFail.GridPips   = GridPips;
          lrFail.s          = s;
@@ -2814,20 +2816,11 @@ void HandleOCODetectionFor(const string system)
          lrFail.EntryPrice = price;
          lrFail.SL         = slInit;
          lrFail.TP         = tpInit;
-         int errCode = 0;
-         if(errcp == "SpreadExceeded")
-            errCode = ERR_SPREAD_EXCEEDED;
-         else if(errcp == "DistanceBandViolation")
-            errCode = ERR_DISTANCE_BAND;
-         lrFail.ErrorCode  = errCode;
-         lrFail.ErrorInfo  = (errcp == "DistanceBandViolation") ? "Distance band violation" :
-                             (errcp == "SpreadExceeded") ? "Spread exceeded" : errcp;
+         lrFail.ErrorCode  = ERR_SPREAD_EXCEEDED;
+         lrFail.ErrorInfo  = "Spread exceeded";
          WriteLog(lrFail);
          return;
       }
-      if(!RefreshRatesChecked(__FUNCTION__))
-         return;
-      double spread = PriceToPips(MathAbs(Ask - Bid));
       ResetLastError();
       int newTicket = OrderSend(Symbol(), retryType, expectedLot, price,
                                 slippage, slInit, tpInit,
@@ -3103,15 +3096,17 @@ void HandleOCODetectionFor(const string system)
             retryTicketB = -1;
          return;
       }
-      string errcp;
-      if(!CanPlaceOrder(price, (type == OP_BUY), errcp))
+      if(!RefreshRatesChecked(__FUNCTION__))
+         return;
+      double spread = PriceToPips(MathAbs(Ask - Bid));
+      if(MaxSpreadPips > 0 && spread > MaxSpreadPips)
       {
          LogRecord lrFail;
          lrFail.Time       = TimeCurrent();
          lrFail.Symbol     = Symbol();
          lrFail.System     = system;
          lrFail.Reason     = "REFILL";
-         lrFail.Spread     = PriceToPips(MathAbs(Ask - Bid));
+         lrFail.Spread     = spread;
          lrFail.Dist       = MathMax(dist, 0);
          lrFail.GridPips   = GridPips;
          lrFail.s          = s;
@@ -3126,25 +3121,15 @@ void HandleOCODetectionFor(const string system)
          lrFail.EntryPrice = price;
          lrFail.SL         = slInit;
          lrFail.TP         = tpInit;
-         int errCode = 0;
-         if(errcp == "SpreadExceeded")
-            errCode = ERR_SPREAD_EXCEEDED;
-         else if(errcp == "DistanceBandViolation")
-            errCode = ERR_DISTANCE_BAND;
-         lrFail.ErrorCode  = errCode;
-         lrFail.ErrorInfo  = (errcp == "DistanceBandViolation") ? "Distance band violation" :
-                             (errcp == "SpreadExceeded") ? "Spread exceeded" : errcp;
+         lrFail.ErrorCode  = ERR_SPREAD_EXCEEDED;
+         lrFail.ErrorInfo  = "Spread exceeded";
          WriteLog(lrFail);
-         PrintFormat("HandleOCODetectionFor: %s - %s, retry next tick", system, lrFail.ErrorInfo);
          if(system == "A")
             retryTicketA = -1;
          else
             retryTicketB = -1;
          return;
       }
-      if(!RefreshRatesChecked(__FUNCTION__))
-         return;
-      double spread = PriceToPips(MathAbs(Ask - Bid));
       ResetLastError();
       int newTicket = OrderSend(Symbol(), type, expectedLot, price,
                                 slippage, slInit, tpInit,

--- a/tests/test_handle_oco_can_place_order.py
+++ b/tests/test_handle_oco_can_place_order.py
@@ -1,9 +1,13 @@
 import pathlib
-import re
 
 
-def test_handle_oco_uses_can_place_order():
+def test_handle_oco_does_not_use_can_place_order():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     content = mc_path.read_text(encoding="utf-8")
-    pattern = r"CanPlaceOrder\s*\(\s*price\s*,\s*\(type == OP_BUY\)\s*,\s*errcp\s*\)"
-    assert re.search(pattern, content), "HandleOCODetectionFor で CanPlaceOrder 呼び出しが必要"
+    idx = content.find("void HandleOCODetectionFor")
+    assert idx != -1, "HandleOCODetectionForが見つからない"
+    end_idx = content.find("\nvoid ", idx + 1)
+    if end_idx == -1:
+        end_idx = len(content)
+    fragment = content[idx:end_idx]
+    assert "CanPlaceOrder" not in fragment, "HandleOCODetectionForでCanPlaceOrderを呼び出さないこと"

--- a/tests/test_handle_oco_distance_band_removed.py
+++ b/tests/test_handle_oco_distance_band_removed.py
@@ -1,7 +1,7 @@
 import pathlib
 
 
-def test_handle_oco_distance_band_violation_logging():
+def test_handle_oco_distance_band_violation_removed():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     content = mc_path.read_text(encoding="utf-8")
     idx = content.find("void HandleOCODetectionFor")
@@ -10,4 +10,4 @@ def test_handle_oco_distance_band_violation_logging():
     if end_idx == -1:
         end_idx = len(content)
     fragment = content[idx:end_idx]
-    assert "DistanceBandViolation" in fragment, "距離帯判定エラーのハンドリングが必要"
+    assert "DistanceBandViolation" not in fragment, "距離帯判定ロジックは削除されるべき"

--- a/tests/test_handle_oco_spread_check.py
+++ b/tests/test_handle_oco_spread_check.py
@@ -6,4 +6,4 @@ def test_handle_oco_spread_check_present():
     content = mc_path.read_text(encoding="utf-8")
     idx = content.find("void HandleOCODetectionFor")
     assert idx != -1, "HandleOCODetectionForが見つからない"
-    assert "SpreadExceeded" in content[idx:], "HandleOCODetectionForにスプレッド判定が必要"
+    assert "Spread exceeded" in content[idx:], "HandleOCODetectionForにスプレッド判定が必要"


### PR DESCRIPTION
## Summary
- Skip CanPlaceOrder checks when reopening after SL and directly attempt OrderSend with a simple spread guard
- Apply the same spread-only validation when re-entering after position correction
- Align tests with the new market reentry behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896f75af0248327a79736fe5f29b6b8