### PR TITLE
Handle RefreshRates failure in CloseAllOrders

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1544,7 +1544,10 @@ void CloseAllOrders(const string reason)
 {
    bool updateDMC = (reason != "RESET_ALIVE" && reason != "RESET_SNAP");
    if(!RefreshRatesChecked(__FUNCTION__))
+   {
       Print("CloseAllOrders: RefreshRatesChecked failed at start");
+      return;
+   }
    int slippage = UseProtectedLimit
                   ? (int)MathRound(SlippagePips * Pip() / _Point)
                   : 0;

--- a/tests/test_close_all_orders_refresh.py
+++ b/tests/test_close_all_orders_refresh.py
@@ -1,7 +1,9 @@
 import pytest
 
 
-def close_all_orders_py(orders, refresh_fail_tickets):
+def close_all_orders_py(orders, refresh_fail_tickets, initial_refresh_ok=True):
+    if not initial_refresh_ok:
+        return []
     processed = []
     for order in orders:
         ticket = order["ticket"]
@@ -19,3 +21,12 @@ def test_skips_failed_refresh_and_continues():
     ]
     result = close_all_orders_py(orders, {2})
     assert result == [1, 3]
+
+
+def test_aborts_when_initial_refresh_fails():
+    orders = [
+        {"ticket": 1},
+        {"ticket": 2},
+    ]
+    result = close_all_orders_py(orders, set(), initial_refresh_ok=False)
+    assert result == []


### PR DESCRIPTION
## Summary
- Abort `CloseAllOrders` when initial `RefreshRatesChecked` fails and log the error
- Extend unit tests to cover abort behavior on initial refresh failure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896f8e49518832785f435dbc6f5ac25