### PR TITLE
Retry OCO order send after failure

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2855,9 +2855,17 @@ void HandleOCODetectionFor(const string system)
          lrFail.ErrorInfo  = ErrorDescription(errCode);
          WriteLog(lrFail);
          if(system == "A")
-            state_A = None;
+         {
+            state_A      = Missing;
+            retryTicketA = 0;
+            retryTypeA   = retryType;
+         }
          else
-            state_B = None;
+         {
+            state_B      = Missing;
+            retryTicketB = 0;
+            retryTypeB   = retryType;
+         }
          return;
       }
       posTicket = newTicket;


### PR DESCRIPTION
## Summary
- Handle OrderSend failures during OCO detection by marking the system as Missing
- Queue retry parameters to resend the order on the next tick while keeping existing logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896fc269a488327a2aab5cdfd41c470