### PR TITLE
Handle SaveDMCState error info in log records

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -885,15 +885,18 @@ void ProcessClosedTrades(const string system,const bool updateDMC,const string r
       lr.SL         = OrderStopLoss();
       lr.TP         = OrderTakeProfit();
       lr.ErrorCode  = 0;
+      lr.ErrorInfo  = "";
       if(updateDMC)
       {
          int err = 0;
          bool saved = SaveDMCState(system, (system == "A") ? stateA : stateB, err);
          if(!saved)
          {
+            string info = ErrorDescription(err);
             if(err != 0)
-               PrintFormat("SaveDMCState(%s) err=%d", system, err);
+               PrintFormat("SaveDMCState(%s) err=%d %s", system, err, info);
             lr.ErrorCode = err;
+            lr.ErrorInfo = info;
          }
       }
       WriteLog(lr);


### PR DESCRIPTION
## Summary
- Store error description in `lr.ErrorInfo` when `SaveDMCState` fails so both `ErrorCode` and `ErrorInfo` are logged

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68970564aa1483279ec58b7d238f9abd