### PR TITLE
Continue deleting pendings on refresh failure

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -1289,7 +1289,11 @@ void DeletePendings(const string system,const string reason)
       if(type != OP_BUYLIMIT && type != OP_SELLLIMIT && type != OP_BUYSTOP && type != OP_SELLSTOP)
          continue;
       if(!RefreshRatesChecked(__FUNCTION__))
-         return;
+      {
+         int tkWarn = OrderTicket();
+         PrintFormat("DeletePendings: RefreshRatesChecked failed, skip ticket %d", tkWarn);
+         continue;
+      }
       string sys, seq;
       if(!ParseComment(OrderComment(), sys, seq))
          continue;


### PR DESCRIPTION
## Summary
- warn and skip pending deletions when refreshing rates fails instead of aborting the whole operation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897068bb5288327b65dcc3a19218f1f