### PR TITLE
CanPlaceOrderでMaxSpreadPips=0時の発注制限を解除

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -451,7 +451,7 @@ bool CanPlaceOrder(double &price,const bool isBuy,string &errorInfo,
    }
 
    double spread = PriceToPips(MathAbs(Ask - Bid));
-   if(checkSpread && spread > MaxSpreadPips)
+   if(checkSpread && MaxSpreadPips > 0 && spread > MaxSpreadPips)
    {
       PrintFormat("Spread %.1f exceeds MaxSpreadPips %.1f", spread, MaxSpreadPips);
       errorInfo = "SpreadExceeded";

--- a/tests/test_can_place_order_max_spread_zero.py
+++ b/tests/test_can_place_order_max_spread_zero.py
@@ -1,0 +1,14 @@
+import pathlib
+
+
+def test_can_place_order_allows_zero_max_spread():
+    mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
+    content = mc_path.read_text(encoding="utf-8")
+    idx = content.find("bool CanPlaceOrder")
+    assert idx != -1, "CanPlaceOrderが見つからない"
+    end_idx = content.find("\ndouble ", idx + 1)
+    if end_idx == -1:
+        end_idx = len(content)
+    fragment = content[idx:end_idx]
+    assert "if(checkSpread && MaxSpreadPips > 0 && spread > MaxSpreadPips)" in fragment, "MaxSpreadPipsが0の場合にスプレッド判定を行わないようにする条件が不足"
+    assert "if(checkSpread && spread > MaxSpreadPips)" not in fragment, "旧来のスプレッド判定が残っている"


### PR DESCRIPTION
## Summary
- CanPlaceOrderのスプレッド判定に`MaxSpreadPips > 0`条件を追加し、0設定時は判定を無効化
- MaxSpreadPipsが0でも発注可能であることを確認するテストを追加

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897101d0d648327a77a730c0f4153f3