### PR TITLE
OCO再発注が特定エラー後に継続されるよう修正

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -3098,9 +3098,17 @@ void HandleOCODetectionFor(const string system)
          PrintFormat("HandleOCODetectionFor: SL/TP within freeze level %.1f pips, retry next tick",
                      PriceToPips(freezeLevel));
          if(system == "A")
-            retryTicketA = -1;
+         {
+            retryTicketA = 0;
+            retryTypeA   = type;
+            state_A      = None;
+         }
          else
-            retryTicketB = -1;
+         {
+            retryTicketB = 0;
+            retryTypeB   = type;
+            state_B      = None;
+         }
          return;
       }
       slInit = NormalizeDouble(slInit, _Digits);
@@ -3133,9 +3141,17 @@ void HandleOCODetectionFor(const string system)
          WriteLog(lrFail);
          Print("HandleOCODetectionFor: SL/TP on wrong side after adjustment, retry next tick");
          if(system == "A")
-            retryTicketA = -1;
+         {
+            retryTicketA = 0;
+            retryTypeA   = type;
+            state_A      = None;
+         }
          else
-            retryTicketB = -1;
+         {
+            retryTicketB = 0;
+            retryTypeB   = type;
+            state_B      = None;
+         }
          return;
       }
       if(!RefreshRatesChecked(__FUNCTION__))
@@ -3167,9 +3183,17 @@ void HandleOCODetectionFor(const string system)
          lrFail.ErrorInfo  = "Spread exceeded";
          WriteLog(lrFail);
          if(system == "A")
-            retryTicketA = -1;
+         {
+            retryTicketA = 0;
+            retryTypeA   = type;
+            state_A      = None;
+         }
          else
-            retryTicketB = -1;
+         {
+            retryTicketB = 0;
+            retryTypeB   = type;
+            state_B      = None;
+         }
          return;
       }
       ResetLastError();


### PR DESCRIPTION
## Summary
- Freeze/Stopレベル違反時に次ティックで再発注するよう処理を変更
- SL/TP方向の不正判定後も再発注を試行するよう調整
- スプレッド超過時もリトライ設定を保持し次ティックで再発注

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689712c053e8832798f723820dcb6dd9