### PR TITLE
Handle RefreshRates failure when processing closed trades

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -815,7 +815,11 @@ void ProcessClosedTrades(const string system,const bool updateDMC,const string r
 
       // 現在のスプレッドを取得（履歴からは取得不可のため近似値）
       if(!RefreshRatesChecked(__FUNCTION__))
-         return;
+      {
+         int tkWarn = OrderTicket();
+         PrintFormat("ProcessClosedTrades: RefreshRatesChecked failed, skip ticket %d", tkWarn);
+         continue;
+      }
       double spreadNow = PriceToPips(MathAbs(Ask - Bid));
       int type  = OrderType();
 


### PR DESCRIPTION
## Summary
- Continue processing other closed trades when `RefreshRatesChecked` fails
- Log a warning for the skipped ticket

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689719f85c588327bb6906b921ea6e51