### PR TITLE
Cast FileWrite result to int in WriteLog

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -125,7 +125,7 @@ void WriteLog(const LogRecord &rec)
    else
    {
       FileSeek(handle, 0, SEEK_END);
-      int written = FileWrite(handle,
+      int written = (int)FileWrite(handle,
          timeStr,
          rec.Symbol,
          rec.System,


### PR DESCRIPTION
## Summary
- Cast the result of `FileWrite` to `int` in WriteLog to avoid type conversion warnings.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68972919e3cc8327b92c723ce63f2afd