### PR TITLE
StringSplit の区切り文字を文字型に統一

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -339,12 +339,12 @@ bool SaveDMCState(const string system,const CDecompMC &state,int &err)
 {
    err=0; bool ok=true;
    string data=state.Serialize();
-   string parts[]; int cnt=StringSplit(data,"|",parts);
+   string parts[]; int cnt=StringSplit(data,'|',parts);
    if(cnt==3)
    {
       int stock=(int)StringToInteger(parts[0]);
       int streak=(int)StringToInteger(parts[1]);
-      string seqParts[]; int n=StringSplit(parts[2],",",seqParts);
+      string seqParts[]; int n=StringSplit(parts[2],',',seqParts);
 
       string prefix=StringFormat("MoveCatcher_%s_%d_%s_",Symbol(),MagicNumber,system);
 


### PR DESCRIPTION
## 概要
- SaveDMCState 内の StringSplit 呼び出しで区切り文字を文字型に変更
- DecompositionMonteCarloMM.mqh の Deserialize が同じ区切り文字を使うことを確認

## テスト
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689729ce62988327b4944c711788ec03