### PR TITLE
refactor: OrderComment を変数経由で大文字化

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -951,7 +951,8 @@ void ProcessClosedTrades(const string system,const bool updateDMC,const string r
             rsn = (hasTP && isTP) ? "TP" : "SL";
          else
          {
-            string cmt = StringToUpper(OrderComment());
+           string cmt = OrderComment();
+           StringToUpper(cmt);
             if(StringFind(cmt, "TP") >= 0)
                rsn = "TP";
             else if(StringFind(cmt, "SL") >= 0)


### PR DESCRIPTION
## Summary
- OrderComment() をいったん変数に代入し、StringToUpper で大文字化するよう変更

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68973113be6883279f47495489286741