### PR TITLE
Fix unmatched brace in InitStrategy

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2798,7 +2798,9 @@ bool InitStrategy()
    bool result = okBuy && okSell;
    state_B = result ? Missing : None;
    return(result);
-  }
+ }
+
+}
 
 //+------------------------------------------------------------------+
 //| Detect filled OCO for specified system                            |


### PR DESCRIPTION
## Summary
- close InitStrategy function with missing brace to balance scope

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689731d122448327a342c2502ae6a6e3