### PR TITLE
Normalize comment casing in ProcessClosedTrades

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -952,7 +952,7 @@ void ProcessClosedTrades(const string system,const bool updateDMC,const string r
          else
          {
            string cmt = OrderComment();
-           StringToUpper(cmt);
+           cmt = StringToUpper(cmt);
             if(StringFind(cmt, "TP") >= 0)
                rsn = "TP";
             else if(StringFind(cmt, "SL") >= 0)


### PR DESCRIPTION
## Summary
- Uppercase order comments before searching for TP/SL flags in `ProcessClosedTrades`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897486b61248327acd13c21b8c99d63