### PR TITLE
Refactor slippage handling and cleanup

### DIFF
--- a/tests/test_init_strategy_slippage.py
+++ b/tests/test_init_strategy_slippage.py
@@ -8,6 +8,6 @@ def test_init_strategy_slippage_always_used():
     m = re.search(r"bool InitStrategy\(\)[\s\S]*?int    slippage = ([^;]+);", code)
     assert m is not None
     expr = m.group(1)
-    assert "SlippagePips" in expr
+    assert "Slippage()" in expr
     assert "UseProtectedLimit" not in expr
 

--- a/tests/test_recover_after_sl_slippage.py
+++ b/tests/test_recover_after_sl_slippage.py
@@ -4,9 +4,6 @@ import pathlib
 def test_recover_after_sl_slippage_conditional():
     mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcher.mq4"
     code = mc_path.read_text(encoding="utf-8")
-    assert "double reSlippagePips = SlippagePips;" in code
-    assert "int    slippage = UseProtectedLimit" in code
-    assert "? (int)MathRound(reSlippagePips * Pip() / _Point)" in code
-    assert ": 0; // UseProtectedLimit=false では slippage=0" in code
+    assert "int    slippage = UseProtectedLimit ? Slippage() : 2147483647;" in code
     assert "StringFormat(\"UseProtectedLimit=%s slippage=%d\"" in code
     assert "UseProtectedLimit ? \"true\" : \"false\"" in code


### PR DESCRIPTION
## Summary
- Add `Slippage()` helper to centralize slippage conversion
- Disable price protection in `RecoverAfterSL` when `UseProtectedLimit` is false
- Update tests for new slippage logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689752bd3028832791e1bde5efe7b553