### PR TITLE
Handle FileMove failure during log migration

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -121,7 +121,8 @@ void MigrateLogIfNeeded()
       string src = TerminalInfoString(TERMINAL_DATA_PATH) + "\\MQL4\\Files\\" + filename;
       string dst = TerminalInfoString(TERMINAL_COMMONDATA_PATH) + "\\Files\\" + filename;
       ResetLastError();
-      if(!FileMove(src, dst, FILE_COMMON))
+      bool moved = FileMove(src, dst);
+      if(!moved)
       {
          int err = GetLastError();
          PrintFormat("MigrateLog: FileMove err=%d %s", err, ErrorDescriptionWrap(err));


### PR DESCRIPTION
## Summary
- migrate log using FileMove without FILE_COMMON and check its result

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68975cb7e2ec83278157da390c30ad3c