### PR TITLE
コメント判定時のStringToUpper呼び出し修正

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -979,7 +979,7 @@ void ProcessClosedTrades(const string system,const bool updateDMC,const string r
          else
          {
            string cmt = OrderComment();
-           cmt = StringToUpper(cmt);
+            StringToUpper(cmt);
             if(StringFind(cmt, "TP") >= 0)
                rsn = "TP";
             else if(StringFind(cmt, "SL") >= 0)


### PR DESCRIPTION
## 概要
- コメント文字列を大文字化する際、代入を行わず`StringToUpper(cmt);`のみ呼び出すよう修正

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68975eec22e883278ed685346f91cc68