### PR TITLE
Fix compile errors in MoveCatcher.mq4

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -121,7 +121,7 @@ void MigrateLogIfNeeded()
       string src = TerminalInfoString(TERMINAL_DATA_PATH) + "\\MQL4\\Files\\" + filename;
       string dst = TerminalInfoString(TERMINAL_COMMONDATA_PATH) + "\\Files\\" + filename;
       ResetLastError();
-      bool moved = FileMove(src, dst);
+      bool moved = FileMove(src, dst, FILE_COMMON);
       if(!moved)
       {
          int err = GetLastError();
@@ -2822,6 +2822,7 @@ bool InitStrategy()
    bool result = okBuy && okSell;
    state_B = result ? Missing : None;
    return(result);
+}
 }
 
 //+------------------------------------------------------------------+


### PR DESCRIPTION
## Summary
- fix FileMove invocation to include FILE_COMMON flag
- add missing closing brace in InitStrategy to balance scope

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689768b820f4832798a60f04ade3609a