### PR TITLE
Fix FileMove call for log migration

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -121,7 +121,7 @@ void MigrateLogIfNeeded()
       string src = TerminalInfoString(TERMINAL_DATA_PATH) + "\\MQL4\\Files\\" + filename;
       string dst = TerminalInfoString(TERMINAL_COMMONDATA_PATH) + "\\Files\\" + filename;
       ResetLastError();
-      bool moved = FileMove(src, dst, FILE_COMMON);
+      bool moved = FileMove(src, dst);
       if(!moved)
       {
          int err = GetLastError();


### PR DESCRIPTION
## Summary
- Remove unsupported FILE_COMMON flag from FileMove call when migrating log file

## Testing
- `pytest -q`
- `mql4compiler` *(fails: command not found)*
- `pip install mql4-compiler` *(fails: no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68976ba5022c8327a2b0a32aa0943171