### PR TITLE
Fix duplicate err variable in HandleOCODetectionFor

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -3626,7 +3626,7 @@ void HandleOCODetectionFor(const string system)
    string sys2, seq2;
    if(!OrderSelect(posTicket, SELECT_BY_TICKET))
    {
-      int err = GetLastError();
+      err = GetLastError();
       PrintFormat("HandleOCODetectionFor: failed to select ticket %d err=%d", posTicket, err);
       return;
    }


### PR DESCRIPTION
## Summary
- reuse function-level error variable instead of redeclaring it inside `HandleOCODetectionFor`

## Testing
- `pytest -q`
- `mql4c experts/MoveCatcher.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68976c9cf5388327a303e08a864cbc5a