### PR TITLE
Fix InitStrategy brace to resolve compile warning

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2823,7 +2823,6 @@ bool InitStrategy()
    state_B = result ? Missing : None;
    return(result);
 }
-}
 
 //+------------------------------------------------------------------+
 //| Detect filled OCO for specified system                            |


### PR DESCRIPTION
## Summary
- InitStrategy 関数末尾の余分な `}` を削除し、`HandleOCODetectionFor` が正しく始まるように修正

## Testing
- `pytest`
- `wine metaeditor64.exe /?` *(MetaEditor 未インストールのため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68976c9814e88327b9e96eb540941bbf