### PR TITLE
Fix unmatched brace in InitStrategy

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2823,6 +2823,7 @@ bool InitStrategy()
    state_B = result ? Missing : None;
    return(result);
 }
+}
 
 //+------------------------------------------------------------------+
 //| Detect filled OCO for specified system                            |


### PR DESCRIPTION
## Summary
- close missing brace in InitStrategy so the function is properly delimited

## Testing
- `cppcheck experts/MoveCatcher.mq4`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689777ef965883279ad55597487fbe32