### PR TITLE
fix: remove extra closing brace

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -2822,7 +2822,6 @@ bool InitStrategy()
    state_B = result ? Missing : None;
    return(result);
 }
-}
 
 //+------------------------------------------------------------------+
 //| Detect filled OCO for specified system                            |


### PR DESCRIPTION
## Summary
- remove leftover closing brace after `InitStrategy` so next function declaration is parsed correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68977c6bed2483278402f59b7c231a03