### PR TITLE
Add MoveCatcherLite expert with comment identifiers

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -1,0 +1,19 @@
+#property strict
+#include <DecompositionMonteCarloMM.mqh>
+
+// コメント識別子
+const string COMMENT_A = "MoveCatcher_A";
+const string COMMENT_B = "MoveCatcher_B";
+
+
+enum MoveCatcherSystem
+{
+   SYSTEM_A,
+   SYSTEM_B
+};
+
+string CommentIdentifier(MoveCatcherSystem sys)
+{
+   return (sys == SYSTEM_A) ? COMMENT_A : COMMENT_B;
+}
+


### PR DESCRIPTION
## Summary
- add MoveCatcherLite expert skeleton that includes DecompositionMonteCarloMM and sets strict property
- define constants and helper for MoveCatcher_A / MoveCatcher_B comments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b92b27b88327a5ebbe1e940da8d6