### PR TITLE
Add basic inputs and derived values to MoveCatcherLite

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -1,6 +1,16 @@
 #property strict
 #include <DecompositionMonteCarloMM.mqh>
 
+// 入力パラメータ
+input double GridPips      = 100.0;
+input double BaseLot       = 0.10;
+input double MaxSpreadPips = 2.0;
+input int    MagicNumber   = 246810;
+
+// 派生値
+const double s   = GridPips / 2.0;
+const double Pip = (Digits == 3 || Digits == 5) ? 10 * Point : Point;
+
 // コメント識別子
 const string COMMENT_A = "MoveCatcher_A";
 const string COMMENT_B = "MoveCatcher_B";


### PR DESCRIPTION
## Summary
- declare GridPips, BaseLot, MaxSpreadPips, and MagicNumber inputs
- define derived values for grid spacing and pip size

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897ba0b4c648327b600e7b2aee21e6c