### PR TITLE
補充指値の発注ロジック修正

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -489,13 +489,13 @@ void CheckRefill()
             int orderType;
             if(priceNow >= entry)
             {
-               price = entry - s * Pip;
-               orderType = OP_BUYLIMIT;
+               price = entry + s * Pip;
+               orderType = OP_SELLLIMIT;
             }
             else
             {
-               price = entry + s * Pip;
-               orderType = OP_SELLLIMIT;
+               price = entry - s * Pip;
+               orderType = OP_BUYLIMIT;
             }
             AdjustPendingPrice(orderType, price);
             refillTicket[SYSTEM_B] = OrderSend(Symbol(), orderType, actualLot, price, 0, 0, 0, COMMENT_B, MagicNumber, 0, clrNONE);
@@ -518,13 +518,13 @@ void CheckRefill()
             int orderType;
             if(priceNow >= entry)
             {
-               price = entry - s * Pip;
-               orderType = OP_BUYLIMIT;
+               price = entry + s * Pip;
+               orderType = OP_SELLLIMIT;
             }
             else
             {
-               price = entry + s * Pip;
-               orderType = OP_SELLLIMIT;
+               price = entry - s * Pip;
+               orderType = OP_BUYLIMIT;
             }
             AdjustPendingPrice(orderType, price);
             refillTicket[SYSTEM_A] = OrderSend(Symbol(), orderType, actualLot, price, 0, 0, 0, COMMENT_A, MagicNumber, 0, clrNONE);


### PR DESCRIPTION
## 概要
- `CheckRefill` の条件分岐を見直し、現在値との位置関係で SellLimit/BuyLimit を出し分け
- SYSTEM_A/SYSTEM_B 双方で同じ補充ロジックを適用

## テスト
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897c9b147c0832788de96db2ba34b74