### PR TITLE
B約定後にチケット変数をリセット

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -546,6 +546,7 @@ void HandleBExecution(int filledTicket)
          OrderDelete(ticketSellLim);
       }
       ticketSellLim = -1;
+      ticketBuyLim  = -1; // 約定済みチケットをリセット
    }
    else if(filledTicket == ticketSellLim)
    {
@@ -554,7 +555,8 @@ void HandleBExecution(int filledTicket)
          LogEvent("OCO_CANCEL", SYSTEM_B, OrderOpenPrice(), 0, 0, GetSpread(), OrderLots());
          OrderDelete(ticketBuyLim);
       }
-      ticketBuyLim = -1;
+      ticketBuyLim  = -1;
+      ticketSellLim = -1; // 約定済みチケットをリセット
    }
 
    if(OrderSelect(filledTicket, SELECT_BY_TICKET))


### PR DESCRIPTION
## 概要
- B側OCOの約定時に、対応するチケットIDを-1にリセットして再処理を防止

## テスト
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897cb333040832796925bb370ad8073