### PR TITLE
Handle RetryOrder failure during initialization

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -353,12 +353,11 @@ int OnInit()
    double slA = entryA - GridPips * Pip;
    double tpA = entryA + GridPips * Pip;
    AdjustStops(true, slA, tpA);
-   if(RetryOrder(false, positionTicket[SYSTEM_A], OP_BUY, actualLot_A, entryA, slA, tpA, COMMENT_A))
-   {
-      lastType[SYSTEM_A] = OP_BUY;
-      PlaceShadowOrder(SYSTEM_A);
-      LogEvent("INIT", SYSTEM_A, entryA, slA, tpA, GetSpread(), actualLot_A);
-   }
+   if(!RetryOrder(false, positionTicket[SYSTEM_A], OP_BUY, actualLot_A, entryA, slA, tpA, COMMENT_A))
+      return(INIT_FAILED);
+   lastType[SYSTEM_A] = OP_BUY;
+   PlaceShadowOrder(SYSTEM_A);
+   LogEvent("INIT", SYSTEM_A, entryA, slA, tpA, GetSpread(), actualLot_A);
 
    double spread = GetSpread();
    if(MaxSpreadPips <= 0 || spread <= MaxSpreadPips)


### PR DESCRIPTION
## Summary
- Return `INIT_FAILED` when the initial RetryOrder in `OnInit` fails
- Prevent System B OCO orders from being placed when System A initialization fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689851b6061083279425a05f23b80638