### PR TITLE
Use pip-based tolerance for closed trade detection

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -304,7 +304,7 @@ void ProcessClosedTrades(MoveCatcherSystem sys)
       double closePrice = OrderClosePrice();
       double tp = OrderTakeProfit();
       double sl = OrderStopLoss();
-      double tol = Point*0.5;
+      double tol = Pip*0.5;
       bool isTP = (tp>0 && MathAbs(closePrice - tp) <= tol);
       bool isSL = (sl>0 && MathAbs(closePrice - sl) <= tol);
       if(isTP || isSL)


### PR DESCRIPTION
## Summary
- replace `Point*0.5` with `Pip*0.5` in `ProcessClosedTrades` to base tolerance on pip size
- confirm `Pip` global constant already defined for flexible broker digit handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b111b1608327a1d7c96d59a469f5