### PR TITLE
RetryOrderでRefreshRates後に最新価格を再計算

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -133,6 +133,8 @@ bool RetryOrder(bool isModify, int &ticket, int orderType, double lot, double &p
    for(int i=0; i<3; i++)
    {
       RefreshRates();
+      if(!isModify && (orderType == OP_BUY || orderType == OP_SELL))
+         price = (orderType == OP_BUY ? Ask : Bid);
       bool success = false;
       if(isModify)
       {


### PR DESCRIPTION
## Summary
- RefreshRates後に最新のAsk/Bidからpriceを再計算し、成行発注で最新価格を使用

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b89831bc8327886ec48b6b7b25c0