### PR TITLE
refactor: compute pip and spacing at init

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -8,8 +8,8 @@ input double MaxSpreadPips = 2.0;
 input int    MagicNumber   = 246810;
 
 // 派生値
-const double s   = GridPips / 2.0;
-const double Pip = (Digits == 3 || Digits == 5) ? 10 * Point : Point;
+double s;
+double Pip;
 
 // コメント識別子
 const string COMMENT_A = "MoveCatcher_A";
@@ -337,6 +337,9 @@ double GetSpread();
 // 初期化
 int OnInit()
 {
+   s   = GridPips / 2.0;
+   Pip = (_Digits==3 || _Digits==5) ? 10*_Point : _Point;
+
    state_A.Init();
    state_B.Init();
 


### PR DESCRIPTION
## Summary
- make s and Pip global variables and compute them during initialization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898b89d54948327a4aff2cc6fe304ce