### PR TITLE
Call RefreshRates before using Ask/Bid

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -73,6 +73,7 @@ double CalcLot(MoveCatcherSystem sys)
 
 double GetSpread()
 {
+   RefreshRates();
    return (Ask - Bid) / Pip;
 }
 
@@ -337,6 +338,7 @@ double GetSpread();
 // 初期化
 int OnInit()
 {
+   RefreshRates();
    state_A.Init();
    state_B.Init();
 


### PR DESCRIPTION
## Summary
- Ensure `OnInit` retrieves fresh price data by calling `RefreshRates()` before using Ask/Bid.
- Update `GetSpread` to call `RefreshRates()` prior to computing the spread.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b8a0294483278a2992d7ea0d0f46