### PR TITLE
Add SlippagePips parameter for MoveCatcherLite

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -5,6 +5,7 @@
 input double GridPips      = 100.0;
 input double BaseLot       = 0.10;
 input double MaxSpreadPips = 2.0;
+input double SlippagePips  = 1.0;
 input int    MagicNumber   = 246810;
 
 // 派生値
@@ -142,7 +143,7 @@ bool RetryOrder(bool isModify, int &ticket, int orderType, double lot, double &p
       }
       else
       {
-         ticket = OrderSend(Symbol(), orderType, lot, price, 0, sl, tp, comment, MagicNumber, 0, clrNONE);
+         ticket = OrderSend(Symbol(), orderType, lot, price, SlippagePips / Pip, sl, tp, comment, MagicNumber, 0, clrNONE);
          success = (ticket > 0);
          if(success && (orderType == OP_BUY || orderType == OP_SELL))
          {

--- a/tests/test_retry_order_slippage_pips.py
+++ b/tests/test_retry_order_slippage_pips.py
@@ -1,0 +1,19 @@
+import pathlib
+import re
+
+
+def test_slippage_pips_used_for_all_orders():
+    mc_path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcherLite.mq4"
+    code = mc_path.read_text(encoding="utf-8")
+
+    # 新しい入力パラメータが存在する
+    assert "input double SlippagePips" in code
+
+    # RetryOrder が成行と指値の両方で呼ばれている
+    assert "RetryOrder(false, positionTicket[SYSTEM_A], OP_BUY" in code
+    assert "RetryOrder(false, ticketBuyLim, OP_BUYLIMIT" in code
+
+    # OrderSend が SlippagePips / Pip を使用している
+    m = re.search(r"OrderSend\([^;]*\);", code)
+    assert m is not None
+    assert "SlippagePips / Pip" in m.group(0)


### PR DESCRIPTION
## Summary
- allow configuring slippage via `SlippagePips`
- ensure RetryOrder uses the slippage value for market and pending orders
- add regression test for slippage handling

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898bc697a408327862179496758a22e