### PR TITLE
Add stop distance guard to MoveCatcherLite

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -99,6 +99,9 @@ double MinStopDist()
 void EnsureTPSL(double entry, bool isBuy, double &sl, double &tp)
 {
    double d = GridPips * Pip;
+   double minLevel = MinStopDist();
+   if(d < minLevel)
+      d = minLevel;
    if(isBuy)
    {
       sl = entry - d;
@@ -353,8 +356,15 @@ double GetSpread();
 // 初期化
 int OnInit()
 {
-   s   = GridPips / 2.0;
    Pip = (_Digits==3 || _Digits==5) ? 10*_Point : _Point;
+   double minLevel = MinStopDist();
+   if(GridPips * Pip < minLevel)
+   {
+      double minPips = minLevel / Pip;
+      PrintFormat("GridPips %.1f is below minimum stop distance %.1f pips, adjusting to %.1f", GridPips, minPips, minPips);
+      GridPips = minPips;
+   }
+   s = GridPips / 2.0;
 
    state_A.Init();
    state_B.Init();


### PR DESCRIPTION
## Summary
- OnInitでブローカーの最小ストップ距離を確認し、GridPipsを必要に応じて調整
- EnsureTPSLで最小ストップ距離を考慮し、不正なSL/TPを回避

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898bc70a5548327ab3885838b1e065e