### PR TITLE
Fix slippage pips conversion in RetryOrder

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -146,7 +146,10 @@ bool RetryOrder(bool isModify, int &ticket, int orderType, double lot, double &p
       }
       else
       {
-         ticket = OrderSend(Symbol(), orderType, lot, price, SlippagePips / Pip, sl, tp, comment, MagicNumber, 0, clrNONE);
+         ticket = OrderSend(
+            Symbol(), orderType, lot, price,
+            SlippagePips * Pip / _Point, // SlippagePips(pips) をポイントに換算
+            sl, tp, comment, MagicNumber, 0, clrNONE);
          success = (ticket > 0);
          if(success && (orderType == OP_BUY || orderType == OP_SELL))
          {

--- a/tests/test_retry_order_slippage_pips.py
+++ b/tests/test_retry_order_slippage_pips.py
@@ -13,7 +13,7 @@ def test_slippage_pips_used_for_all_orders():
     assert "RetryOrder(false, positionTicket[SYSTEM_A], OP_BUY" in code
     assert "RetryOrder(false, ticketBuyLim, OP_BUYLIMIT" in code
 
-    # OrderSend が SlippagePips / Pip を使用している
+    # OrderSend が SlippagePips * Pip / _Point を使用している
     m = re.search(r"OrderSend\([^;]*\);", code)
     assert m is not None
-    assert "SlippagePips / Pip" in m.group(0)
+    assert "SlippagePips * Pip / _Point" in m.group(0)


### PR DESCRIPTION
## Summary
- convert slippage from pips to points in `RetryOrder`
- document the pips-to-points conversion
- update test to expect the new slippage conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c1501acc83278ec0fff2aed86ebd