### PR TITLE
fix: use _Point in MinStopDist

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -94,7 +94,8 @@ double MinStopDist()
 {
    double stop   = MarketInfo(Symbol(), MODE_STOPLEVEL);
    double freeze = MarketInfo(Symbol(), MODE_FREEZELEVEL);
-   return MathMax(stop, freeze) * Point;
+   // stop と freeze はポイント数 → _Point で価格に換算
+   return MathMax(stop, freeze) * _Point;
 }
 
 void EnsureTPSL(double entry, bool isBuy, double &sl, double &tp)


### PR DESCRIPTION
## Summary
- use `_Point` when computing minimal stop distance
- clarify comment about converting stop/freeze levels using `_Point`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898c1532bac83279a372538425b6abc