### PR TITLE
CheckRefillで残存指値の重複補充を防止

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -638,7 +638,8 @@ void CheckRefill()
          }
       }
    }
-   else if(!hasA && hasB && refillTicket[SYSTEM_A] < 0)
+   // Buy/Sell の指値が残っている場合は補充注文を出さない（重複発注を防ぐ）
+   else if(!hasA && hasB && ticketBuyLim < 0 && ticketSellLim < 0 && refillTicket[SYSTEM_A] < 0)
    {
       if(OrderSelect(posB, SELECT_BY_TICKET))
       {


### PR DESCRIPTION
## 概要
- CheckRefillの条件に`ticketBuyLim`と`ticketSellLim`のチェックを追加し、既存の指値がある場合に補充注文が出ないよう改善
- 不要な補充発注を避ける旨のコメントを追加

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c155b2e08327a0f4a81bf3e03a81