### PR TITLE
Convert slippage from pips to integer points

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -154,9 +154,10 @@ bool RetryOrder(bool isModify, int &ticket, int orderType, double lot, double &p
       }
       else
       {
+         int slippage = (int)MathRound(SlippagePips * Pip / _Point); // pips→pointsに換算し整数化
          ticket = OrderSend(
             Symbol(), orderType, lot, price,
-            SlippagePips * Pip / _Point, // SlippagePips(pips) をポイントに換算
+            slippage,
             sl, tp, comment, MagicNumber, 0, clrNONE);
          success = (ticket > 0);
          if(success && (orderType == OP_BUY || orderType == OP_SELL))

--- a/tests/test_retry_order_slippage_pips.py
+++ b/tests/test_retry_order_slippage_pips.py
@@ -13,7 +13,8 @@ def test_slippage_pips_used_for_all_orders():
     assert "RetryOrder(false, positionTicket[SYSTEM_A]," in code
     assert "RetryOrder(false, ticketBuyLim, OP_BUYLIMIT" in code
 
-    # OrderSend が SlippagePips * Pip / _Point を使用している
+    # SlippagePips をポイントへ換算し整数化した値を OrderSend で使用している
+    assert "int slippage = (int)MathRound(SlippagePips * Pip / _Point)" in code
     m = re.search(r"OrderSend\([^;]*\);", code)
     assert m is not None
-    assert "SlippagePips * Pip / _Point" in m.group(0)
+    assert "slippage" in m.group(0)


### PR DESCRIPTION
## Summary
- convert `SlippagePips` to integer points before `OrderSend`
- adjust tests for new slippage handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898cf404f708327b821b2a9b1e2fc56