### PR TITLE
refactor: use local grid variable for initialization

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -382,14 +382,15 @@ double GetSpread();
 int OnInit()
 {
    Pip = (_Digits==3 || _Digits==5) ? 10*_Point : _Point;
+   double grid = GridPips;
    double minLevel = MinStopDist();
-   if(GridPips * Pip < minLevel)
+   if(grid * Pip < minLevel)
    {
       double minPips = minLevel / Pip;
-      PrintFormat("GridPips %.1f is below minimum stop distance %.1f pips, adjusting to %.1f", GridPips, minPips, minPips);
-      GridPips = minPips;
+      PrintFormat("GridPips %.1f is below minimum stop distance %.1f pips, adjusting to %.1f", grid, minPips, minPips);
+      grid = minPips;
    }
-   s = GridPips / 2.0;
+   s = grid / 2.0;
 
    state_A.Init();
    state_B.Init();


### PR DESCRIPTION
## Summary
- declare and use a local `grid` variable in OnInit for min stop calculations and `s` setup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898cf3f01988327af22c98600094aa5