### PR TITLE
OrderClose結果の検証とエラーログを追加

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -239,15 +239,23 @@ int FindPositions(MoveCatcherSystem sys, int &tickets[], datetime &times[])
    return ArraySize(tickets);
 }
 
-void CloseTicket(int ticket, MoveCatcherSystem sys)
+bool CloseTicket(int ticket, MoveCatcherSystem sys)
 {
    if(OrderSelect(ticket, SELECT_BY_TICKET))
    {
       double lots = OrderLots();
       double price = (OrderType()==OP_BUY) ? Bid : Ask;
       LogEvent("DUPLICATE_CLOSE", sys, OrderOpenPrice(), OrderStopLoss(), OrderTakeProfit(), GetSpread(), lots);
-      OrderClose(ticket, lots, price, 0, clrNONE);
+      ResetLastError();
+      bool ok = OrderClose(ticket, lots, price, 0, clrNONE);
+      if(!ok)
+      {
+         int err = GetLastError();
+         PrintFormat("OrderClose failed. ticket=%d error=%d", ticket, err);
+      }
+      return(ok);
    }
+   return(false);
 }
 
 void CorrectDuplicatePositions()
@@ -372,7 +380,7 @@ bool EnterOppositeDirection(MoveCatcherSystem sys);
 void ManageSystem(MoveCatcherSystem sys);
 void CheckRefill();
 void CorrectDuplicatePositions();
-void CloseTicket(int ticket, MoveCatcherSystem sys);
+bool CloseTicket(int ticket, MoveCatcherSystem sys);
 void LogEvent(string reason, MoveCatcherSystem sys, double entry, double sl, double tp, double spread, double actualLot);
 void EnsureTPSL(double entry, bool isBuy, double &sl, double &tp);
 void AdjustPendingPrice(int orderType, double &price);


### PR DESCRIPTION
## Summary
- CloseTicketでOrderCloseの結果を検証し、失敗時にエラーコードをログ出力
- CloseTicketがboolを返すよう変更し、上位でのエラー処理に備える

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898cf424e5c83279ce81093c4f1509e