### PR TITLE
refactor: use DoubleToString for log formatting

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -80,12 +80,16 @@ double GetSpread()
 
 void LogEvent(string reason, MoveCatcherSystem sys, double entry, double sl, double tp, double spread, double actualLot)
 {
-   string sysStr = (sys == SYSTEM_A) ? "A" : "B";
-   PrintFormat("Reason=%s Entry=%.*f SL=%.*f TP=%.*f Spread=%.1f System=%s actualLot=%.2f",
+   string sysStr   = (sys == SYSTEM_A) ? "A" : "B";
+   string entryStr = DoubleToString(entry, _Digits);
+   string slStr    = DoubleToString(sl, _Digits);
+   string tpStr    = DoubleToString(tp, _Digits);
+
+   PrintFormat("Reason=%s Entry=%s SL=%s TP=%s Spread=%.1f System=%s actualLot=%.2f",
                reason,
-               _Digits, entry,
-               _Digits, sl,
-               _Digits, tp,
+               entryStr,
+               slStr,
+               tpStr,
                spread,
                sysStr,
                actualLot);


### PR DESCRIPTION
## Summary
- format entry, sl, and tp using DoubleToString before logging

## Testing
- `pytest`
- `python manual_log_check.py`

------
https://chatgpt.com/codex/tasks/task_e_6898d5dc299883279819a046c3e4067c