### PR TITLE
fix: refine closed trade checks

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -353,9 +353,20 @@ void ProcessClosedTrades(MoveCatcherSystem sys)
       double closePrice = OrderClosePrice();
       double tp = OrderTakeProfit();
       double sl = OrderStopLoss();
-      double tol = Pip*0.5;
-      bool isTP = (tp>0 && MathAbs(closePrice - tp) <= tol);
-      bool isSL = (sl>0 && MathAbs(closePrice - sl) <= tol);
+      double tol = Pip * SlippagePips;
+      int type = OrderType();
+      bool isTP = false;
+      bool isSL = false;
+      if(type == OP_BUY)
+      {
+         if(tp > 0 && closePrice >= tp - tol) isTP = true;
+         if(sl > 0 && closePrice <= sl + tol) isSL = true;
+      }
+      else if(type == OP_SELL)
+      {
+         if(tp > 0 && closePrice <= tp + tol) isTP = true;
+         if(sl > 0 && closePrice >= sl - tol) isSL = true;
+      }
       if(isTP || isSL)
       {
          if(sys==SYSTEM_A) state_A.OnTrade(isTP); else state_B.OnTrade(isTP);

--- a/tests/test_close_reason.py
+++ b/tests/test_close_reason.py
@@ -3,12 +3,23 @@ import pytest
 
 def estimate_reason(order):
     point = order.get("point", 0.00001)
-    tol = point * 0.5
+    tol = point * 1.0
     close_price = order["close"]
     tp = order.get("tp", 0)
     sl = order.get("sl", 0)
-    is_tp = abs(close_price - tp) <= tol and tp > 0
-    is_sl = abs(close_price - sl) <= tol and sl > 0
+    typ = order.get("type", "buy")
+    is_tp = False
+    is_sl = False
+    if typ == "buy":
+        if tp > 0 and close_price >= tp - tol:
+            is_tp = True
+        if sl > 0 and close_price <= sl + tol:
+            is_sl = True
+    else:
+        if tp > 0 and close_price <= tp + tol:
+            is_tp = True
+        if sl > 0 and close_price >= sl - tol:
+            is_sl = True
     if is_tp:
         return "TP"
     if is_sl:

--- a/tests/test_pip_tolerance.py
+++ b/tests/test_pip_tolerance.py
@@ -8,7 +8,7 @@ def pip_value(digits):
 
 
 def tol(digits):
-    return pip_value(digits) * 0.5
+    return pip_value(digits) * 1.0
 
 
 @pytest.mark.parametrize("digits", [5, 3])
@@ -17,12 +17,12 @@ def test_process_closed_trades_tolerance(digits):
     pip = pip_value(digits)
     tolerance = tol(digits)
     close_price = base
-    take_profit = base + 0.4 * pip
-    stop_loss = base - 0.4 * pip
+    take_profit = base + 0.9 * pip
+    stop_loss = base - 0.9 * pip
     assert abs(close_price - take_profit) <= tolerance
     assert abs(close_price - stop_loss) <= tolerance
-    take_profit_far = base + 0.6 * pip
-    stop_loss_far = base - 0.6 * pip
+    take_profit_far = base + 1.1 * pip
+    stop_loss_far = base - 1.1 * pip
     assert abs(close_price - take_profit_far) > tolerance
     assert abs(close_price - stop_loss_far) > tolerance
 
@@ -33,8 +33,8 @@ def test_find_shadow_pending_tolerance(digits):
     pip = pip_value(digits)
     tolerance = tol(digits)
     target = base
-    price_close = base + 0.4 * pip
-    price_far = base + 0.6 * pip
+    price_close = base + 0.9 * pip
+    price_far = base + 1.1 * pip
     assert abs(price_close - target) <= tolerance
     assert abs(price_far - target) > tolerance
 
@@ -45,7 +45,7 @@ def test_ensure_tpsl_tolerance(digits):
     pip = pip_value(digits)
     tolerance = tol(digits)
     desired = base
-    current_close = base + 0.4 * pip
-    current_far = base + 0.6 * pip
+    current_close = base + 0.9 * pip
+    current_far = base + 1.1 * pip
     assert abs(current_close - desired) <= tolerance
     assert abs(current_far - desired) > tolerance


### PR DESCRIPTION
## Summary
- use SlippagePips to compute tolerance for closed trade evaluation
- compare close price to TP/SL with direction-aware inequalities
- adjust tolerance in Python tests

## Testing
- `pytest`
- `python - <<'PY'
import MetaTrader5 as mt5
print('initialize:', mt5.initialize())
PY` *(fails: ModuleNotFoundError: No module named 'MetaTrader5')*
- `pip install MetaTrader5` *(fails: ERROR: Could not find a version that satisfies the requirement MetaTrader5)*

------
https://chatgpt.com/codex/tasks/task_e_6898d6dc8a4c8327b09809d38a47cf0d