### PR TITLE
Add TP/SL fallback detection in ProcessClosedTrades

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -367,6 +367,22 @@ void ProcessClosedTrades(MoveCatcherSystem sys)
          if(tp > 0 && closePrice <= tp + tol) isTP = true;
          if(sl > 0 && closePrice >= sl - tol) isSL = true;
       }
+      double entry = OrderOpenPrice();
+      double d = GridPips * Pip;
+      if(type == OP_BUY)
+      {
+         double tpFallback = entry + d;
+         double slFallback = entry - d;
+         if(!isTP && closePrice >= tpFallback - tol) isTP = true;
+         if(!isSL && closePrice <= slFallback + tol) isSL = true;
+      }
+      else if(type == OP_SELL)
+      {
+         double tpFallback = entry - d;
+         double slFallback = entry + d;
+         if(!isTP && closePrice <= tpFallback + tol) isTP = true;
+         if(!isSL && closePrice >= slFallback - tol) isSL = true;
+      }
       if(isTP || isSL)
       {
          if(sys==SYSTEM_A) state_A.OnTrade(isTP); else state_B.OnTrade(isTP);

--- a/tests/test_process_closed_trades_fallback.py
+++ b/tests/test_process_closed_trades_fallback.py
@@ -1,0 +1,48 @@
+import math
+
+
+def detect_result(close_price, tp, sl, entry, order_type, grid_pips, pip, slippage_pips):
+    tol = pip * slippage_pips
+    is_tp = False
+    is_sl = False
+    if order_type == 'buy':
+        if tp > 0 and close_price >= tp - tol:
+            is_tp = True
+        if sl > 0 and close_price <= sl + tol:
+            is_sl = True
+        tp_fallback = entry + grid_pips * pip
+        sl_fallback = entry - grid_pips * pip
+        if not is_tp and close_price >= tp_fallback - tol:
+            is_tp = True
+        if not is_sl and close_price <= sl_fallback + tol:
+            is_sl = True
+    else:
+        if tp > 0 and close_price <= tp + tol:
+            is_tp = True
+        if sl > 0 and close_price >= sl - tol:
+            is_sl = True
+        tp_fallback = entry - grid_pips * pip
+        sl_fallback = entry + grid_pips * pip
+        if not is_tp and close_price <= tp_fallback + tol:
+            is_tp = True
+        if not is_sl and close_price >= sl_fallback - tol:
+            is_sl = True
+    return is_tp, is_sl
+
+
+def test_fallback_triggers_tp_for_buy_when_tp_missing():
+    entry = 1.0000
+    pip = 0.0001
+    d = 100 * pip
+    close_price = entry + d
+    is_tp, is_sl = detect_result(close_price, 0, entry - d, entry, 'buy', 100, pip, 1.0)
+    assert is_tp and not is_sl
+
+
+def test_fallback_triggers_sl_for_sell_when_sl_missing():
+    entry = 1.0000
+    pip = 0.0001
+    d = 100 * pip
+    close_price = entry + d
+    is_tp, is_sl = detect_result(close_price, entry - d, 0, entry, 'sell', 100, pip, 1.0)
+    assert not is_tp and is_sl


### PR DESCRIPTION
## Summary
- add fallback TP/SL detection based on entry price ± GridPips
- test missing TP/SL triggers with fallback logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898e525d5088327a7e58367bd12eded