### PR TITLE
Limit closed trade scan and add debug logging for re-entry triggers

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -325,6 +325,14 @@ void ProcessClosedTrades(MoveCatcherSystem sys)
 {
    int idx = (int)sys;
    datetime lastTime = lastCloseTime[idx];
+
+   // 最新の履歴のみを対象にする
+   if(!HistorySelect(lastTime, TimeCurrent()))
+   {
+      PrintFormat("HistorySelect failed: %d", GetLastError());
+      return;
+   }
+
    int tickets[]; datetime times[];
    int newTickets[];
    if(sys==SYSTEM_A) ArrayCopy(newTickets,lastTicketsA); else ArrayCopy(newTickets,lastTicketsB);
@@ -387,6 +395,11 @@ void ProcessClosedTrades(MoveCatcherSystem sys)
       {
          if(sys==SYSTEM_A) state_A.OnTrade(isTP); else state_B.OnTrade(isTP);
          if(isTP) needReverse[idx] = true; else if(isSL) needReEnter[idx] = true;
+
+         // デバッグログ: TP/SL 検知を通知
+         string sysStr = (sys == SYSTEM_A) ? "A" : "B";
+         string result = isTP ? "TP" : "SL";
+         PrintFormat("ProcessClosedTrades: system=%s ticket=%d result=%s", sysStr, OrderTicket(), result);
       }
    }
    lastCloseTime[idx] = newLastTime;


### PR DESCRIPTION
## Summary
- Restrict closed trade processing to recent history via `HistorySelect`
- Detect TP/SL results and log them, updating re-entry flags

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ecc3ece88327b4b8ce6e59c7e4cc