### PR TITLE
needReverse/needReEnter処理中は補充をスキップ

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -516,6 +516,7 @@ void OnTick()
 
    ManageSystem(SYSTEM_A);
    ManageSystem(SYSTEM_B);
+   bool hasPending = needReverse[SYSTEM_A] || needReverse[SYSTEM_B] || needReEnter[SYSTEM_A] || needReEnter[SYSTEM_B];
    if(needResendOCO)
    {
       if(positionTicket[SYSTEM_B] > 0)
@@ -552,7 +553,7 @@ void OnTick()
          }
       }
    }
-   else
+   else if(!hasPending)
       CheckRefill();
 }
 
@@ -656,14 +657,30 @@ void ManageSystem(MoveCatcherSystem sys)
    if(needReverse[idx])
    {
       if(EnterOppositeDirection(sys))
+      {
          needReverse[idx] = false;
+         if(refillTicket[idx] > 0)
+         {
+            if(OrderSelect(refillTicket[idx], SELECT_BY_TICKET))
+               OrderDelete(refillTicket[idx]);
+            refillTicket[idx] = -1;
+         }
+      }
       return;
    }
 
    if(needReEnter[idx])
    {
       if(ReEnterSameDirection(sys))
+      {
          needReEnter[idx] = false;
+         if(refillTicket[idx] > 0)
+         {
+            if(OrderSelect(refillTicket[idx], SELECT_BY_TICKET))
+               OrderDelete(refillTicket[idx]);
+            refillTicket[idx] = -1;
+         }
+      }
    }
 }
 

--- a/tests/test_log_events_exist.py
+++ b/tests/test_log_events_exist.py
@@ -1,0 +1,7 @@
+import pathlib
+
+def test_log_events_tp_reverse_sl_reentry():
+    path = pathlib.Path(__file__).resolve().parents[1] / "experts" / "MoveCatcherLite.mq4"
+    content = path.read_text(encoding="utf-8")
+    assert 'LogEvent("TP_REVERSE"' in content
+    assert 'LogEvent("SL_REENTRY"' in content


### PR DESCRIPTION
## 概要
- needReverse/needReEnterが残っている間はCheckRefillを実行しないように修正
- 反転/リエントリ成功時に不要な補充指値を削除
- TP_REVERSEとSL_REENTRYのログ出力を確認するテストを追加

## テスト
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898ee1c60ac832788d36f95eff89d41