### PR TITLE
refillTicket 削除時のエラーハンドリングを追加

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -662,8 +662,26 @@ void ManageSystem(MoveCatcherSystem sys)
          if(refillTicket[idx] > 0)
          {
             if(OrderSelect(refillTicket[idx], SELECT_BY_TICKET))
-               OrderDelete(refillTicket[idx]);
-            refillTicket[idx] = -1;
+            {
+               ResetLastError();
+               bool delOk = OrderDelete(refillTicket[idx]);
+               if(!delOk)
+               {
+                  int err = GetLastError();
+                  PrintFormat("OrderDelete failed (ticket=%d, err=%d)", refillTicket[idx], err);
+                  ResetLastError();
+                  delOk = OrderDelete(refillTicket[idx]);
+                  if(!delOk)
+                  {
+                     err = GetLastError();
+                     PrintFormat("OrderDelete retry failed (ticket=%d, err=%d)", refillTicket[idx], err);
+                  }
+               }
+               if(delOk || !OrderSelect(refillTicket[idx], SELECT_BY_TICKET))
+                  refillTicket[idx] = -1;
+            }
+            else
+               refillTicket[idx] = -1;
          }
       }
       return;
@@ -677,8 +695,26 @@ void ManageSystem(MoveCatcherSystem sys)
          if(refillTicket[idx] > 0)
          {
             if(OrderSelect(refillTicket[idx], SELECT_BY_TICKET))
-               OrderDelete(refillTicket[idx]);
-            refillTicket[idx] = -1;
+            {
+               ResetLastError();
+               bool delOk = OrderDelete(refillTicket[idx]);
+               if(!delOk)
+               {
+                  int err = GetLastError();
+                  PrintFormat("OrderDelete failed (ticket=%d, err=%d)", refillTicket[idx], err);
+                  ResetLastError();
+                  delOk = OrderDelete(refillTicket[idx]);
+                  if(!delOk)
+                  {
+                     err = GetLastError();
+                     PrintFormat("OrderDelete retry failed (ticket=%d, err=%d)", refillTicket[idx], err);
+                  }
+               }
+               if(delOk || !OrderSelect(refillTicket[idx], SELECT_BY_TICKET))
+                  refillTicket[idx] = -1;
+            }
+            else
+               refillTicket[idx] = -1;
          }
       }
    }


### PR DESCRIPTION
## Summary
- OrderDelete の成否を確認し、失敗時はエラーをログ出力してリトライ
- 削除成功またはチケット不存在時のみ refillTicket を初期化

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898f3d99cdc832799e6fd27fd8a1601