### PR TITLE
Allow ProcessClosedTrades to accept prefixed comments

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -380,7 +380,9 @@ void ProcessClosedTrades(MoveCatcherSystem sys)
       PrintFormat("ProcessClosedTrades: history ticket=%d close=%s magic=%d comment=%s type=%d", histTk, TimeToString(ct), OrderMagicNumber(), OrderComment(), OrderType());
       if(OrderMagicNumber()!=MagicNumber || OrderSymbol()!=Symbol()) continue;
       int type=OrderType(); if(type!=OP_BUY && type!=OP_SELL) continue;
-      if(OrderComment()!=CommentIdentifier(sys)) continue;
+      string comment = OrderComment();
+      string prefix = CommentIdentifier(sys);
+      if(StringSubstr(comment,0,StringLen(prefix))!=prefix) continue;
       if(ct<lastTime) continue;
       if(ct==lastTime)
       {

--- a/tests/test_process_closed_trades.py
+++ b/tests/test_process_closed_trades.py
@@ -2,12 +2,13 @@ import pytest
 
 
 def process_closed_trades_py(history, system, last_time, last_tickets):
+    identifier = f"MoveCatcher_{system}"
     tickets = []
     times = []
     new_last_time = last_time
     new_last_tickets = list(last_tickets)
     for order in history:
-        if order["system"] != system:
+        if not order["comment"].startswith(identifier):
             continue
         ct = order["close_time"]
         if ct < last_time:
@@ -26,13 +27,13 @@ def process_closed_trades_py(history, system, last_time, last_tickets):
 
 def test_same_time_closures_are_processed():
     history = [
-        {"ticket": 1, "system": "A", "close_time": 100},
+        {"ticket": 1, "comment": "MoveCatcher_A_foo", "close_time": 100},
     ]
     tickets, last_time, last_tickets = process_closed_trades_py(history, "A", 0, [])
     assert tickets == [1]
 
     # 新しい注文が同一時刻で決済された場合でも処理されることを確認
-    history.append({"ticket": 2, "system": "A", "close_time": 100})
+    history.append({"ticket": 2, "comment": "MoveCatcher_A_bar", "close_time": 100})
     tickets, last_time, last_tickets = process_closed_trades_py(history, "A", last_time, last_tickets)
     assert tickets == [2]
     assert last_time == 100


### PR DESCRIPTION
## Summary
- Handle trade history entries when comments start with `MoveCatcher_A` or `MoveCatcher_B`
- Adjust closed trade processing test to use comment prefixes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68991a3e47e08327868704a66964d0bd