### PR TITLE
fix: refresh price and normalize tp/sl

### DIFF
--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -57,28 +57,32 @@ bool InitStrategy()
       return(false);
    }
    int    slippage = Slippage();
-   double price = Ask;
-   double distA = DistanceToExistingPositions(price);
+   double entrySL, entryTP;
+   double price    = Ask;
+   double oldPrice = price;
+   double distA    = DistanceToExistingPositions(price);
    if(UseDistanceBand && distA >= 0){
       // first distance band check
    }
+
    RefreshRates();
+   price = Ask;
    if(UseDistanceBand && distA >= 0){
       // recheck after price refresh
    }
-   double entrySL, entryTP;
-   double oldPrice = price;
+
    if(price != oldPrice)
    {
       int type = OP_BUY;
       if(type == OP_BUY){
-         entrySL = price - PipsToPrice(GridPips);
-         entryTP = price + PipsToPrice(GridPips);
+         entrySL = NormalizeDouble(price - PipsToPrice(GridPips), _Digits);
+         entryTP = NormalizeDouble(price + PipsToPrice(GridPips), _Digits);
       }else{
-         entrySL = price + PipsToPrice(GridPips);
-         entryTP = price - PipsToPrice(GridPips);
+         entrySL = NormalizeDouble(price + PipsToPrice(GridPips), _Digits);
+         entryTP = NormalizeDouble(price - PipsToPrice(GridPips), _Digits);
       }
    }
+
    distA = DistanceToExistingPositions(price);
    return(true);
 }


### PR DESCRIPTION
## Summary
- refresh market price after calling RefreshRates and recompute entry levels when price changes
- normalize calculated TP/SL to terminal precision

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899da59710c83279ea71b81d2457ae5