### PR TITLE
Fix price refresh and normalized entry levels

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -57,26 +57,27 @@ bool InitStrategy()
       return(false);
    }
    int    slippage = Slippage();
-   double price = Ask;
-   double distA = DistanceToExistingPositions(price);
+   double price    = Ask;
+   double oldPrice = price;
+   double distA    = DistanceToExistingPositions(price);
    if(UseDistanceBand && distA >= 0){
       // first distance band check
    }
    RefreshRates();
+   price = Ask;
    if(UseDistanceBand && distA >= 0){
       // recheck after price refresh
    }
    double entrySL, entryTP;
-   double oldPrice = price;
    if(price != oldPrice)
    {
       int type = OP_BUY;
       if(type == OP_BUY){
-         entrySL = price - PipsToPrice(GridPips);
-         entryTP = price + PipsToPrice(GridPips);
+         entrySL = NormalizeDouble(price - PipsToPrice(GridPips), _Digits);
+         entryTP = NormalizeDouble(price + PipsToPrice(GridPips), _Digits);
       }else{
-         entrySL = price + PipsToPrice(GridPips);
-         entryTP = price - PipsToPrice(GridPips);
+         entrySL = NormalizeDouble(price + PipsToPrice(GridPips), _Digits);
+         entryTP = NormalizeDouble(price - PipsToPrice(GridPips), _Digits);
       }
    }
    distA = DistanceToExistingPositions(price);

--- a/tests/test_recalculate_entry_levels_when_price_changes.py
+++ b/tests/test_recalculate_entry_levels_when_price_changes.py
@@ -7,7 +7,7 @@ def test_recalculate_entry_levels_when_price_changes():
     assert "double oldPrice = price;" in content, "旧価格の保存がない"
     assert "if(price != oldPrice)" in content, "価格変化チェックがない"
     after = content.split("if(price != oldPrice)")[1].split("distA = DistanceToExistingPositions(price);")[0]
-    assert "entrySL = price - PipsToPrice(GridPips);" in after, "買い側のSL再計算がない"
-    assert "entrySL = price + PipsToPrice(GridPips);" in after, "売り側のSL再計算がない"
-    assert "entryTP = price + PipsToPrice(GridPips);" in after, "買い側のTP再計算がない"
-    assert "entryTP = price - PipsToPrice(GridPips);" in after, "売り側のTP再計算がない"
+    assert "entrySL = NormalizeDouble(price - PipsToPrice(GridPips), _Digits);" in after, "買い側のSL再計算がない"
+    assert "entrySL = NormalizeDouble(price + PipsToPrice(GridPips), _Digits);" in after, "売り側のSL再計算がない"
+    assert "entryTP = NormalizeDouble(price + PipsToPrice(GridPips), _Digits);" in after, "買い側のTP再計算がない"
+    assert "entryTP = NormalizeDouble(price - PipsToPrice(GridPips), _Digits);" in after, "売り側のTP再計算がない"


### PR DESCRIPTION
## Summary
- Update initialisation logic to refresh market price after `RefreshRates` and normalize entry TP/SL levels in `MoveCatcher.mq4`.
- Align regression test with normalized entry level calculations.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899dc47499c83278c4bca3dc77dc21a