### PR TITLE
Fix buy order price to use Ask

### DIFF
--- a/experts/MoveCatcher.mq4
+++ b/experts/MoveCatcher.mq4
@@ -141,7 +141,8 @@ void RecoverAfterSL(double price,bool isBuy,double entry)
 void ProcessClosedTrades(){
    LogEvent("TP_REVERSE", "A", 0);
    LogEvent("SL_REENTRY", "B", 0);
-   RetryOrder(false, positionTicket[SYSTEM_A], OP_BUY, Bid, 0, 0);
+   // Buy 系成行の価格指定は Ask を使用
+   RetryOrder(false, positionTicket[SYSTEM_A], OP_BUY, Ask, 0, 0);
    int ticketBuyLim = 0; double price = Ask, sl=0, tp=0;
    RetryOrder(false, ticketBuyLim, OP_BUYLIMIT, price, sl, tp);
 }

--- a/experts/MoveCatcherLite.mq4
+++ b/experts/MoveCatcherLite.mq4
@@ -144,7 +144,8 @@ void RecoverAfterSL(double price,bool isBuy,double entry)
 void ProcessClosedTrades(){
    LogEvent("TP_REVERSE", "A", 0);
    LogEvent("SL_REENTRY", "B", 0);
-   RetryOrder(false, positionTicket[SYSTEM_A], OP_BUY, Bid, 0, 0);
+   // Buy 系の成行注文は Ask 基準で価格を指定
+   RetryOrder(false, positionTicket[SYSTEM_A], OP_BUY, Ask, 0, 0);
    int ticketBuyLim = 0; double price = Ask, sl=0, tp=0;
    RetryOrder(false, ticketBuyLim, OP_BUYLIMIT, price, sl, tp);
 }


### PR DESCRIPTION
## Summary
- Ensure ProcessClosedTrades uses Ask price for market buy orders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899de1b0d388327bde8ff5fabff69be