### PR TITLE
fix: adjust order management and normalization

### DIFF
--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -55,7 +55,9 @@ int CountPendings(const string comment)
       if(!OrderSelect(i, SELECT_BY_POS, MODE_TRADES)) continue;
       if(OrderMagicNumber()!=MagicNumber) continue;
       if(OrderComment()!=comment) continue;
-      if(OrderType()!=OP_BUY && OrderType()!=OP_SELL) count++;
+      int type = OrderType();
+      if(type==OP_BUYLIMIT || type==OP_SELLLIMIT || type==OP_BUYSTOP || type==OP_SELLSTOP)
+         count++;
    }
    return(count);
 }
@@ -67,20 +69,55 @@ void CancelPendings(const string comment)
       if(!OrderSelect(i, SELECT_BY_POS, MODE_TRADES)) continue;
       if(OrderMagicNumber()!=MagicNumber) continue;
       if(OrderComment()!=comment) continue;
-      if(OrderType()==OP_BUY || OrderType()==OP_SELL) continue;
-      OrderDelete(OrderTicket());
+      int type = OrderType();
+      if(type==OP_BUYLIMIT || type==OP_SELLLIMIT || type==OP_BUYSTOP || type==OP_SELLSTOP)
+      {
+         if(!OrderDelete(OrderTicket()))
+            Print("OrderDelete failed: ",GetLastError());
+      }
+   }
+}
+
+void CloseExtraPositions(const string comment)
+{
+   int tickets[];
+   for(int i=0; i<OrdersTotal(); i++)
+   {
+      if(!OrderSelect(i, SELECT_BY_POS, MODE_TRADES)) continue;
+      if(OrderMagicNumber()!=MagicNumber) continue;
+      if(OrderComment()!=comment) continue;
+      int type = OrderType();
+      if(type==OP_BUY || type==OP_SELL)
+      {
+         int n = ArraySize(tickets);
+         ArrayResize(tickets, n+1);
+         tickets[n] = OrderTicket();
+      }
+   }
+   for(int i=ArraySize(tickets)-1; i>=1; i--)
+   {
+      int ticket = tickets[i];
+      if(OrderSelect(ticket, SELECT_BY_TICKET))
+      {
+         double price = (OrderType()==OP_BUY)?Bid:Ask;
+         if(!OrderClose(ticket, OrderLots(), price, 0))
+            Print("OrderClose failed: ",GetLastError());
+      }
    }
 }
 
 void SetTPSL(int ticket)
 {
    if(!OrderSelect(ticket, SELECT_BY_TICKET)) return;
-   if(OrderType()!=OP_BUY && OrderType()!=OP_SELL) return;
+   int type = OrderType();
+   if(type!=OP_BUY && type!=OP_SELL) return;
    if(OrderTakeProfit()!=0 || OrderStopLoss()!=0) return;
-   double price = OrderOpenPrice();
+   double price = NormalizeDouble(OrderOpenPrice(), _Digits);
    double tp, sl;
-   if(OrderType()==OP_BUY){ tp = price + d; sl = price - d; }
-   else                  { tp = price - d; sl = price + d; }
+   if(type==OP_BUY){ tp = price + d; sl = price - d; }
+   else            { tp = price - d; sl = price + d; }
+   tp = NormalizeDouble(tp, _Digits);
+   sl = NormalizeDouble(sl, _Digits);
    OrderModify(ticket, price, sl, tp, 0);
 }
 
@@ -88,8 +125,9 @@ void PlaceRefill(const string comment, bool longExist, double basePrice)
 {
    if(!SpreadOK()) return;
    CDecompMC &dmc = (comment=="MoveCatcher_A") ? dmcA : dmcB;
-   double lot = NormalizeLot(BaseLot * dmc.NextLot());
+   double lot   = NormalizeLot(BaseLot * dmc.NextLot());
    double price = longExist ? basePrice + s : basePrice - s;
+   price = NormalizeDouble(price, _Digits);
    int type = longExist ? OP_SELLLIMIT : OP_BUYLIMIT;
    OrderSend(Symbol(), type, lot, price, 0, 0, 0, comment, MagicNumber, 0, clrRed);
 }
@@ -103,18 +141,18 @@ int OnInit()
    dmcA.Init();
    dmcB.Init();
 
-   double lotA = NormalizeLot(BaseLot * dmcA.NextLot());
-   double priceA = Ask;
-   double tpA = priceA + d;
-   double slA = priceA - d;
+   double lotA   = NormalizeLot(BaseLot * dmcA.NextLot());
+   double priceA = NormalizeDouble(Ask, _Digits);
+   double tpA    = NormalizeDouble(priceA + d, _Digits);
+   double slA    = NormalizeDouble(priceA - d, _Digits);
    int ticketA = OrderSend(Symbol(), OP_BUY, lotA, priceA, 0, slA, tpA, "MoveCatcher_A", MagicNumber, 0, clrBlue);
    if(ticketA<0) Print("Init order A failed: ",GetLastError());
 
    if(SpreadOK())
    {
-      double lotB = NormalizeLot(BaseLot * dmcB.NextLot());
-      double sellPrice = priceA + s;
-      double buyPrice  = priceA - s;
+      double lotB      = NormalizeLot(BaseLot * dmcB.NextLot());
+      double sellPrice = NormalizeDouble(priceA + s, _Digits);
+      double buyPrice  = NormalizeDouble(priceA - s, _Digits);
       OrderSend(Symbol(), OP_SELLLIMIT, lotB, sellPrice, 0, 0, 0, "MoveCatcher_B", MagicNumber, 0, clrRed);
       OrderSend(Symbol(), OP_BUYLIMIT,  lotB, buyPrice,  0, 0, 0, "MoveCatcher_B", MagicNumber, 0, clrRed);
    }
@@ -130,8 +168,11 @@ void HandleClose(CDecompMC &dmc, const string comment, int prevType, bool win)
    int type = prevType;
    if(win) type = (prevType==OP_BUY) ? OP_SELL : OP_BUY;
    double price = (type==OP_BUY) ? Ask : Bid;
+   price = NormalizeDouble(price, _Digits);
    double tp = (type==OP_BUY) ? price + d : price - d;
    double sl = (type==OP_BUY) ? price - d : price + d;
+   tp = NormalizeDouble(tp, _Digits);
+   sl = NormalizeDouble(sl, _Digits);
    int ticket = OrderSend(Symbol(), type, lot, price, 0, sl, tp, comment, MagicNumber, 0, clrBlue);
    if(ticket<0) Print("Re-entry failed: ",GetLastError());
 }
@@ -139,11 +180,13 @@ void HandleClose(CDecompMC &dmc, const string comment, int prevType, bool win)
 void ProcessClosed()
 {
    int total = OrdersHistoryTotal();
+   datetime latest = lastHist;
    for(int i=total-1; i>=0; i--)
    {
       if(!OrderSelect(i, SELECT_BY_POS, MODE_HISTORY)) continue;
       if(OrderMagicNumber()!=MagicNumber) continue;
-      if(OrderCloseTime() <= lastHist) break;
+      datetime ct = OrderCloseTime();
+      if(ct <= lastHist) break;
       string comment = OrderComment();
       bool win = (OrderProfit() >= 0);
       int type = OrderType();
@@ -151,12 +194,17 @@ void ProcessClosed()
          HandleClose(dmcA, comment, type, win);
       else if(comment=="MoveCatcher_B")
          HandleClose(dmcB, comment, type, win);
+      if(ct > latest) latest = ct;
    }
-   lastHist = TimeCurrent();
+   lastHist = latest;
 }
 
 void CheckPendings()
 {
+   // 同系統多重ポジションの整理
+   CloseExtraPositions("MoveCatcher_A");
+   CloseExtraPositions("MoveCatcher_B");
+
    // 片割れキャンセル & TP/SL設定
    int posA=0,posB=0;
    for(int i=OrdersTotal()-1; i>=0; i--)


### PR DESCRIPTION
## Summary
- ensure pending order checks explicitly handle limit and stop types and report deletion errors
- normalize prices and stop levels to symbol digits and track last close time accurately
- remove duplicate positions per system before managing pendings

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6899e6e713088327b738d9fa4f3a85ce