### PR TITLE
修正: 決済処理の判定とOnDeinitのシグネチャ

### DIFF
--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -188,7 +188,15 @@ void ProcessClosed()
       datetime ct = OrderCloseTime();
       if(ct <= lastHist) break;
       string comment = OrderComment();
-      bool win = (OrderProfit() >= 0);
+
+      double closePrice = OrderClosePrice();
+      double tp = OrderTakeProfit();
+      double sl = OrderStopLoss();
+      bool win = false;
+      if(tp>0 && MathAbs(closePrice - tp) <= Pip/2.0) win = true;
+      else if(sl>0 && MathAbs(closePrice - sl) <= Pip/2.0) win = false;
+      else win = (OrderProfit() >= 0);
+
       int type = OrderType();
       if(comment=="MoveCatcher_A")
          HandleClose(dmcA, comment, type, win);
@@ -260,4 +268,7 @@ void OnTick()
    CheckPendings();
 }
 
-int OnDeinit(){return(0);}
+void OnDeinit(const int reason)
+{
+   // 特に後処理は不要
+}


### PR DESCRIPTION
## 概要
- TP/SLでの決済を正しく判定するよう修正
- OnDeinitを正しいシグネチャに変更

## テスト
- `python -m unittest` (テストなし)


------
https://chatgpt.com/codex/tasks/task_e_6899e94d5c048327a8d238e31250c58f