### PR TITLE
Fix reference usage causing compilation error

### DIFF
--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -128,8 +128,9 @@ void SetTPSL(int ticket)
 void PlaceRefill(const string comment, bool longExist, double basePrice)
 {
    if(!SpreadOK()) return;
-   CDecompMC &dmc = (comment=="MoveCatcher_A") ? dmcA : dmcB;
-   double lot   = NormalizeLot(BaseLot * dmc.NextLot());
+   double lot   = NormalizeLot(
+      BaseLot * ((comment=="MoveCatcher_A") ? dmcA.NextLot() : dmcB.NextLot())
+   );
    double price = longExist ? basePrice + s : basePrice - s;
    price = NormalizeDouble(price, _Digits);
    int type = longExist ? OP_SELLLIMIT : OP_BUYLIMIT;


### PR DESCRIPTION
## Summary
- avoid illegal reference in PlaceRefill and compute lot size directly

## Testing
- `metaeditor /compile:MoveCatcher.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899f1c6e5888327ab752dd52fc6bfd4