### PR TITLE
Fix lot scaling after trades and skip canceled orders

### DIFF
--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -197,6 +197,8 @@ void ProcessClosed()
    {
       if(!OrderSelect(i, SELECT_BY_POS, MODE_HISTORY)) continue;
       if(OrderMagicNumber()!=MagicNumber) continue;
+      int type = OrderType();
+      if(type!=OP_BUY && type!=OP_SELL) continue;      // 未約定指値の履歴を除外
       datetime ct = OrderCloseTime();
       if(ct <= lastHist) break;
       string comment = OrderComment();
@@ -209,7 +211,6 @@ void ProcessClosed()
       else if(sl>0 && MathAbs(closePrice - sl) <= Pip/2.0) win = false;
       else win = (OrderProfit() >= 0);
 
-      int type = OrderType();
       if(comment=="MoveCatcher_A")
          HandleClose(dmcA, comment, type, win);
       else if(comment=="MoveCatcher_B")

--- a/include/DecompositionMonteCarloMM.mqh
+++ b/include/DecompositionMonteCarloMM.mqh
@@ -62,11 +62,10 @@ private:
 /*── WIN ──*/
    void winStep(){
       int n = ArraySize(seq);
-      // 条件成立時は連勝数+1、不成立時は現状維持
-      if(n==2 && seq[0]==0 && seq[1]==1)
-         streak++;
 
-      if(n==2){ seq[0]=0; seq[1]=1; }
+      if(n==2){
+         seq[0]=0; seq[1]=1;
+      }
       else if(n==3){
          int center = seq[1];            // 中央の値を取得
          Erase(seq,0);                   // 先頭を削除
@@ -75,10 +74,18 @@ private:
          int right = left + center%2;    // 右値を計算
          seq[0] = left;                  // 左値を設定
          Ins(seq,1,right);               // 右値を挿入
-      }else{
+      }
+      else{
          Erase(seq,0); Erase(seq,ArraySize(seq)-1);
       }
+
       if(seq[0]==0) avgA(); else avgB();      // ← if/else で呼び出し
+
+      // 連勝数の更新：最終シーケンスが基本形なら加算、それ以外はリセット
+      if(ArraySize(seq)==2 && seq[0]==0 && seq[1]==1)
+         streak++;
+      else
+         streak = 1;
    }
 
 /*── LOSE ──*/


### PR DESCRIPTION
## Summary
- Correct DMCMM streak handling so the lot coefficient increases properly after wins
- Ignore historical entries for unfilled pending orders to keep DMCMM state accurate

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6899f44c932483279bee64e32e1d55a7