### PR TITLE
Ensure TP/SL applied after pending orders fill

### DIFF
--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -280,7 +280,7 @@ void MaintainPendingAfterFill(){
 }
 
 void MaintainPendingAfterFillOne(SystemState &S){
-   if(S.activeTicket>0 && (S.pendUpTicket>0 || S.pendDnTicket>0)){
+   if(S.activeTicket>0){
       if(S.pendUpTicket>0) DeleteTicket(S.pendUpTicket,S.name,"AFTER");
       if(S.pendDnTicket>0) DeleteTicket(S.pendDnTicket,S.name,"AFTER");
       S.pendUpTicket=0; S.pendDnTicket=0;


### PR DESCRIPTION
## Summary
- Ensure SL/TP is set on filled pending orders even if counterpart pending was cancelled earlier

## Testing
- `wine metaeditor64.exe /compile:MoveCatcher.mq4 /log` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b81d827488327852f4a62e7c57acc