### PR TITLE
Add spread cap validation before sending market orders

### DIFF
--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -163,6 +163,11 @@ int CloseReasonFromHistory(int ticket){
 // ====== Send helpers ======
 int SendMarket(SystemState &S, int dir){
    RefreshRates();
+   double spr = (Ask-Bid)/PIP();
+   if(InpMaxSpreadPips>0.0 && spr>InpMaxSpreadPips){
+      LogAlways(StringFormat("[OPEN_SKIP_SPREAD][%s] spr=%.1f", S.name, spr));
+      return 0;
+   }
    double price = MktPriceByDir(dir);
    double sl,tp; CalcSLTP(dir, price, InpGridPips, sl, tp);
    int type = OrderTypeByDir(dir);


### PR DESCRIPTION
## Summary
- validate MaxSpreadPips before all market orders and log `OPEN_SKIP_SPREAD`

## Testing
- `mql4 -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cb45749488327b1cb44479a57bcd1