### PR TITLE
Add invalid stop check in MoveCatcher

### DIFF
--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -170,6 +170,14 @@ int SendMarket(SystemState &S, int dir){
    }
    double price = MktPriceByDir(dir);
    double sl,tp; CalcSLTP(dir, price, InpGridPips, sl, tp);
+
+   // --- 価格乖離チェック：スプレッド過大で ±d を満たせない場合は発注しない ---
+   bool invalid = (dir>0) ? (sl>=Bid || tp<=Ask) : (sl<=Ask || tp>=Bid);
+   if(invalid){
+      LogAlways(StringFormat("[OPEN_SKIP_INVALID_STOPS][%s] Bid=%.5f Ask=%.5f SL=%.5f TP=%.5f",
+               S.name, Bid, Ask, sl, tp));
+      return 0;
+   }
    int type = OrderTypeByDir(dir);
    string cmt = StringFormat("MoveCatcher_%s", S.name);
    double lot = ComputeLotAndLog(S);          // ★ 発注直前評価＆数列ログ


### PR DESCRIPTION
## Summary
- avoid OrderSend error 130 by skipping market orders when computed stops are invalid due to large spread

## Testing
- `wine metaeditor /? >/tmp/meta.log && tail -n 20 /tmp/meta.log` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ccb3519388327a1e68c7cc63f796c