### PR TITLE
Include missing side in refill skip spread log

### DIFF
--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -247,7 +247,7 @@ void TryRefillOneSideIfOneLeft(){
    // Spread判定（0で無効）
    double spr = (Ask-Bid)/PIP();
    if(InpMaxSpreadPips>0.0 && spr>InpMaxSpreadPips){
-      Log("[REFILL_STRICT_SKIP_SPREAD]");
+      Log(StringFormat("[REFILL_STRICT_SKIP_SPREAD][%s] spr=%.1f", missingName, spr));
       return;
    }
 


### PR DESCRIPTION
## Summary
- log which system (A/B) skipped refill due to spread and the current spread value

## Testing
- `wine --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eedc6659c83278a3544ef109d790e