### PR TITLE
補充時の閾値判定を撤廃

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **Project:** MoveCatcher Lite Strict（A/B 系統・最大2本）
 **Target:** MetaTrader 4（MQL4）
-**方針:** Pending/OCO を一切使用せず、2本目は相手建値±s から `GapAllowedPips` 以内に入った瞬間のみ成行（疑似MIT）で建てる。補充は勝敗外（Neutral）で DMCMM は発注時に評価。A/B ロット計算を独立／共通で切り替え可能。
+**方針:** Pending/OCO を一切使用せず、2本目は相手建値±s から `GapAllowedPips` 以内に入った瞬間のみ成行（疑似MIT）で建てる。補充は生存側建値±s到達で即成行（`GapAllowedPips` 閾値なし）し、勝敗外（Neutral）で DMCMM は発注時に評価。A/B ロット計算を独立／共通で切り替え可能。
 
 ---
 
@@ -14,7 +14,7 @@
 | TpOffsetPips | double | 1.0 | TP距離への加算値（pips） |
 | BaseLot | double | 0.10 | 実ロット = BaseLot × 係数 |
 | MaxSpreadPips | double | 2.0 | 置く前のスプレッド上限（補充時にも流用） |
-| GapAllowedPips | double | 0.3 | entryAlive±s許容差（pips） |
+| GapAllowedPips | double | 0.3 | entryAlive±s許容差（pips、再エントリのみ） |
 | MagicNumber | int | 246810 | EA識別 |
 | **UseSharedDMCMM** | bool | **false** | **false**=A/B独立、**true**=A/B共通（係数・勝敗シーケンスを共有） |
 | LogMode | ENUM | FULL | ログレベル（**FULL**=詳細ログ、**MIN**=最小限） |
@@ -74,8 +74,8 @@
   * 生存 Long → **Sell @ `entryAlive + s`**
   * 生存 Short → **Buy  @ `entryAlive − s`**
 * 発注条件（そのティックのみ）
-  * **Sell 補充**：`|Bid − P*| ≤ GapAllowedPips` かつ `Spread ≤ MaxSpreadPips`
-  * **Buy 補充** ：`|Ask − P*| ≤ GapAllowedPips` かつ `Spread ≤ MaxSpreadPips`
+  * **Sell 補充**：`Bid ≥ P*` かつ `Spread ≤ MaxSpreadPips`
+  * **Buy 補充** ：`Ask ≤ P*` かつ `Spread ≤ MaxSpreadPips`
 * 執行
   * `OrderSend(OP_SELL/BUY, ..., deviation=EpsilonPoints)`（`P*±ε` 超過は拒否）
   * Filled→**SL=±d, TP=±(d+o)** 設定、コメント `MoveCatcher_B`（または欠落側ラベル）。
@@ -104,7 +104,7 @@
 
 ## 受け入れチェック
 
-1. 補充は常に疑似MIT＆Pendingなし。`|Bid/Ask−P*|≤GapAllowedPips` かつ `Spread≤MaxSpreadPips` のティックのみ約定。
+1. 補充は常に疑似MIT＆Pendingなし。`Bid ≥ P*`（Sell）/`Ask ≤ P*`（Buy）かつ `Spread≤MaxSpreadPips` のティックのみ約定（`GapAllowedPips` 閾値なし）。
 2. TP/SL 時のみ勝敗更新：
    * 独立：該当系統の DMCMM だけ更新。
    * 共通：共通 DMCMM を更新（同ティック 2 件は順序規則で逐次実行）。

--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -3,7 +3,7 @@
 //| A/B二系統（Ultimate-Lite Strict, 実TP/実SL）                     |
 //|  - 初期化: Aを成行で1本建て、Bは置かず監視のみ                   |
 //|  - TP/SL決済時のみ勝敗判定→生存側建値±sからGapAllowedPips以内で反転/順方向へ再エントリ|
-//|  - 欠落補充: 生存側建値±sからGapAllowedPips以内に入った瞬間だけ成行（疑似MIT）|
+//|  - 欠落補充: 生存側建値±s到達で即成行（疑似MIT、GapAllowedPips閾値なし）|
 //|  - Pending/OCOは一切使わず、Spread判定は発注直前のみ（0で無効） |
 //|  - 実ロット = BaseLot × DMCMM係数（発注直前に毎回評価）         |
 //|  - A/Bロット計算は UseSharedDMCMM=falseで独立、trueで共通       |
@@ -21,7 +21,7 @@ input double   InpGridPips       = 100;     // d: TP/SL 距離（pips）(TPはd+
 input double   InpTpOffsetPips   = 0;       // TPオフセット（pips）
 input double   InpBaseLot        = 0.01;    // BaseLot
 input double   InpMaxSpreadPips  = 2.0;     // 置く時の最大スプレッド[pips]（0で無効）
-input double   InpGapAllowedPips = 0.3;     // entryAlive±s許容差[pips]
+input double   InpGapAllowedPips = 0.3;     // entryAlive±s許容差[pips]（再エントリのみ）
 input int      InpMagic          = 246810;  // マジック
 input bool     InpUseSharedDMCMM = false;   // trueでA/B共通DMCMM
 enum ENUM_LOG_MODE { LOG_FULL=0, LOG_MIN=1 };
@@ -210,11 +210,11 @@ int  MarketCount(){
 
 // 欠落時の補充：疑似MIT（Pendingを使わず生存側建値±sで成行）
 void TryRefillOneSideIfOneLeft(){
-   static bool armed=false;
+   static bool   armed=false;
    static string armSys="";
    static double armPrice=0.0;
-   static int armDir=0;
-   static double prevDiff=1e9;      // 直前の価格乖離（ヒット判定用）
+   static int    armDir=0;
+   static double prevDiff=1e9;      // 直前の価格差（符号付き）
 
    RefreshTickets();
    int mktCnt = MarketCount();
@@ -224,7 +224,7 @@ void TryRefillOneSideIfOneLeft(){
    if((missingIsA && ReArmA.armed) || (!missingIsA && ReArmB.armed)){ armed=false; prevDiff=1e9; return; }
 
    // 生存側と欠落側
-   bool aliveIsA = (A.activeTicket>0);
+   bool   aliveIsA = (A.activeTicket>0);
    double s = Pip2Pt(InpGridPips/2.0);
    double target;         // 生存側建値±s
    int    dir;            // 補充方向（生存側反転）
@@ -240,10 +240,9 @@ void TryRefillOneSideIfOneLeft(){
       missingName = A.name;
    }
 
-   double gap = Pip2Pt(InpGapAllowedPips);
-   double diff = (dir>0) ? MathAbs(Ask - target) : MathAbs(Bid - target);
+   double diff = (dir>0) ? (Ask - target) : (target - Bid);
    if(!armed || armSys!=missingName || !Almost(armPrice,target,1)){
-      armed=true; armSys=missingName; armPrice=target; armDir=dir; prevDiff=gap+1; // アーム直後の即時ヒットを許容
+      armed=true; armSys=missingName; armPrice=target; armDir=dir; prevDiff=1e9; // アーム直後の即時ヒットを許容
       Log(StringFormat("[REFILL_STRICT_ARM][%s] P*=%.5f", missingName, target));
    }
 
@@ -254,7 +253,7 @@ void TryRefillOneSideIfOneLeft(){
       return;
    }
 
-   bool hit = (diff<=gap && prevDiff>gap);
+   bool hit = (diff<=0 && prevDiff>0);
    prevDiff = diff;
    if(!hit) return;                // 未到達 or 滞留中
 


### PR DESCRIPTION
## 概要
- 欠落補充に GapAllowedPips の閾値を適用しないよう仕様書と EA を更新
- InpGapAllowedPips は再エントリ用の許容差としてのみ使用

## テスト
- `make test` : make: *** No rule to make target 'test'.  Stop.


------
https://chatgpt.com/codex/tasks/task_e_689f40ab44a88327add781ddb30ee3f8