### PR TITLE
Cancel reentry when opposite system closes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@
 
 * **TP（Win）**：EA が Win 判定→（独立なら該当系統／共通なら共通）`winStep()`→**反転エントリを監視**：生存側建値 `entryAlive` ± `s` から ±`GapAllowedPips` 以内に入ったティックのみ成行→**SL=±d, TP=±(d+o)**。
 * **SL（Loss）**：同様に `loseStep()`→**順方向エントリを監視**：生存側建値 `entryAlive` ± `s` から ±`GapAllowedPips` 以内に入ったティックのみ成行→**SL=±d, TP=±(d+o)**。
+* 監視中に反対系統が TP/SL で決済された場合は当該監視を解除し、欠落補充モードへ移行（ログ `[REENTRY_STRICT_CANCEL]`）。
 * ロットは毎回「発注直前」に `BaseLot×係数` を丸め/クリップ。監視中にスプレッド上限を超えるティックでは発注しない。
 
 ### 欠落補充（疑似MIT／Pendingなし）
@@ -97,6 +98,7 @@
 * `LogMode=FULL`：既存ログをすべて出力。
 * `LogMode=MIN` ：`Log()` レベルの詳細ログを抑制し、必要最小限のみ出力。
 * 既存：`INIT, TP_REVERSE, SL_REENTRY, SANITY_TRIM`
+* 再エントリ：`REENTRY_STRICT_ARM`, `REENTRY_STRICT_HIT`, `REENTRY_STRICT_SKIP_SPREAD`, `REENTRY_STRICT_REQUOTE/REJECT`, `REENTRY_STRICT_CANCEL`
 * 補充：`REFILL_STRICT_ARM`（監視開始）, `REFILL_STRICT_HIT`（約定）, `REFILL_STRICT_SKIP_SPREAD`, `REFILL_STRICT_REQUOTE/REJECT`
 * モード注記：各ログに `LotMode={INDEPENDENT|SHARED}` を付与（係数の意味づけを明確化）。
 

--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -331,6 +331,10 @@ void DetectCloseAndArm(){
       int dirNew = (reason>0) ? -dirPrev : dirPrev;
 
       if(evs[k].sys==0){
+         if(ReArmB.armed){
+            ReArmB.armed=false;
+            Log(StringFormat("[REENTRY_STRICT_CANCEL][%s]", B.name));
+         }
          if(reason>0){ WinStep(A); LogAlways(StringFormat("TP_REVERSE[%s] ticket=%d", A.name, evs[k].ticket)); }
          else{        LoseStep(A); LogAlways(StringFormat("SL_REENTRY[%s] ticket=%d", A.name, evs[k].ticket)); }
 
@@ -342,6 +346,10 @@ void DetectCloseAndArm(){
          ReArmA.prevDiff=gapArm+1;                     // アーム直後の即時ヒットを許容
          Log(StringFormat("[REENTRY_STRICT_ARM][%s] P*=%.5f", A.name, target));
       }else{
+         if(ReArmA.armed){
+            ReArmA.armed=false;
+            Log(StringFormat("[REENTRY_STRICT_CANCEL][%s]", A.name));
+         }
          if(reason>0){ WinStep(B); LogAlways(StringFormat("TP_REVERSE[%s] ticket=%d", B.name, evs[k].ticket)); }
          else{        LoseStep(B); LogAlways(StringFormat("SL_REENTRY[%s] ticket=%d", B.name, evs[k].ticket)); }
 


### PR DESCRIPTION
## Summary
- cancel re-entry monitoring if the opposite system closes and log `[REENTRY_STRICT_CANCEL]`
- document re-entry cancellation and log enumeration in the specification

## Testing
- `nl -ba MoveCatcher.mq4 | sed -n '333,357p'`
- `nl -ba AGENTS.md | sed -n '64,106p'`


------
https://chatgpt.com/codex/tasks/task_e_689f43409efc8327ba25fab189829d5a