### PR TITLE
Arm refill after initial entry

### DIFF
--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -483,6 +483,8 @@ int OnInit(){
    if(tA>0){
      A.activeTicket=tA; A.lastDir=dir; A.entryPrice=MktPriceByDir(dir);
    }
+   // 初回エントリー後に欠落補充をアーム
+   TryRefillOneSideIfOneLeft();
    return(INIT_SUCCEEDED);
 }
 


### PR DESCRIPTION
## Summary
- call `TryRefillOneSideIfOneLeft` after the first entry to arm refill logic immediately

## Testing
- `metaeditor64.exe /compile:MoveCatcher.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f5019a8e083279309f5a522fe72ab