### PR TITLE
Apply gap threshold to refill logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **Project:** MoveCatcher Lite Strict（A/B 系統・最大2本）
 **Target:** MetaTrader 4（MQL4）
-**方針:** Pending/OCO を一切使用せず、2本目は相手建値±s から `GapAllowedPips` 以内に入った瞬間のみ成行（疑似MIT）で建てる。補充は生存側建値±s到達で即成行（`GapAllowedPips` 閾値なし）し、勝敗外（Neutral）で DMCMM は発注時に評価。A/B ロット計算を独立／共通で切り替え可能。
+**方針:** Pending/OCO を一切使用せず、2本目は相手建値±s から `GapAllowedPips` 以内に入った瞬間のみ成行（疑似MIT）で建てる。補充も生存側建値±s から `GapAllowedPips` 以内に入った瞬間のみ成行とし、勝敗外（Neutral）で DMCMM は発注時に評価。A/B ロット計算を独立／共通で切り替え可能。
 
 ---
 
@@ -14,7 +14,7 @@
 | TpOffsetPips | double | 1.0 | TP距離への加算値（pips） |
 | BaseLot | double | 0.10 | 実ロット = BaseLot × 係数 |
 | MaxSpreadPips | double | 2.0 | 置く前のスプレッド上限（補充時にも流用） |
-| GapAllowedPips | double | 0.3 | entryAlive±s許容差（pips、再エントリのみ） |
+| GapAllowedPips | double | 0.3 | entryAlive±s許容差（pips、再エントリ・欠落補充） |
 | MagicNumber | int | 246810 | EA識別 |
 | **UseSharedDMCMM** | bool | **false** | **false**=A/B独立、**true**=A/B共通（係数・勝敗シーケンスを共有） |
 | LogMode | ENUM | FULL | ログレベル（**FULL**=詳細ログ、**MIN**=最小限） |
@@ -75,8 +75,8 @@
   * 生存 Long → **Sell @ `entryAlive + s`**
   * 生存 Short → **Buy  @ `entryAlive − s`**
 * 発注条件（そのティックのみ）
-  * **Sell 補充**：`Bid ≥ P*` かつ `Spread ≤ MaxSpreadPips`
-  * **Buy 補充** ：`Ask ≤ P*` かつ `Spread ≤ MaxSpreadPips`
+  * **Sell 補充**：`Bid` が `P*` から ±`GapAllowedPips` 以内 かつ `Spread ≤ MaxSpreadPips`
+  * **Buy 補充** ：`Ask` が `P*` から ±`GapAllowedPips` 以内 かつ `Spread ≤ MaxSpreadPips`
 * 執行
   * `OrderSend(OP_SELL/BUY, ..., deviation=EpsilonPoints)`（`P*±ε` 超過は拒否）
   * Filled→**SL=±d, TP=±(d+o)** 設定、コメント `MoveCatcher_B`（または欠落側ラベル）。
@@ -106,7 +106,7 @@
 
 ## 受け入れチェック
 
-1. 補充は常に疑似MIT＆Pendingなし。`Bid ≥ P*`（Sell）/`Ask ≤ P*`（Buy）かつ `Spread≤MaxSpreadPips` のティックのみ約定（`GapAllowedPips` 閾値なし）。
+1. 補充は常に疑似MIT＆Pendingなし。`Bid/Ask` が `P*` から ±`GapAllowedPips` 以内 かつ `Spread≤MaxSpreadPips` のティックのみ約定。
 2. TP/SL 時のみ勝敗更新：
    * 独立：該当系統の DMCMM だけ更新。
    * 共通：共通 DMCMM を更新（同ティック 2 件は順序規則で逐次実行）。


### PR DESCRIPTION
## Summary
- support `GapAllowedPips` threshold when executing refill orders
- document that gap tolerance applies to both re-entry and refill

## Testing
- `wine --version` *(fails: command not found)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689f525ffb0c8327939b41c944eae36f