### PR TITLE
Fix re-entry skip logic

### DIFF
--- a/MoveCatcher.mq4
+++ b/MoveCatcher.mq4
@@ -384,7 +384,10 @@ void TryReentryStrict(){
       if(InpMaxSpreadPips>0.0 && spr>InpMaxSpreadPips){
          Log(StringFormat("[REENTRY_STRICT_SKIP_SPREAD][%s]", A.name));
       }else{
-         if(B.activeTicket==0){
+         double diff = (ReArmA.dir>0)? MathAbs(Ask - ReArmA.target) : MathAbs(Bid - ReArmA.target);
+         bool hit   = (diff<=gap && ReArmA.prevDiff>gap);
+         ReArmA.prevDiff = diff;
+         if(hit){
             int tk = SendMarket(A, ReArmA.dir);
             if(tk>0){
                A.activeTicket=tk; A.lastDir=ReArmA.dir; A.entryPrice=MktPriceByDir(ReArmA.dir);
@@ -395,22 +398,6 @@ void TryReentryStrict(){
                string tag=(err==ERR_REQUOTE||err==ERR_OFF_QUOTES)?"REENTRY_STRICT_REQUOTE":"REENTRY_STRICT_REJECT";
                Log(StringFormat("[%s][%s] err=%d", tag, A.name, err));
             }
-         }else{
-            double diff = (ReArmA.dir>0)? MathAbs(Ask - ReArmA.target) : MathAbs(Bid - ReArmA.target);
-            bool hit = (diff<=gap && ReArmA.prevDiff>gap);
-            ReArmA.prevDiff = diff;
-            if(hit){
-               int tk = SendMarket(A, ReArmA.dir);
-               if(tk>0){
-                  A.activeTicket=tk; A.lastDir=ReArmA.dir; A.entryPrice=MktPriceByDir(ReArmA.dir);
-                  LogAlways(StringFormat("[REENTRY_STRICT_HIT][%s] ticket=%d", A.name, tk));
-                  ReArmA.armed=false;
-               }else{
-                  int err=GetLastError();
-                  string tag=(err==ERR_REQUOTE||err==ERR_OFF_QUOTES)?"REENTRY_STRICT_REQUOTE":"REENTRY_STRICT_REJECT";
-                  Log(StringFormat("[%s][%s] err=%d", tag, A.name, err));
-               }
-            }
          }
       }
    }
@@ -420,7 +407,10 @@ void TryReentryStrict(){
       if(InpMaxSpreadPips>0.0 && spr>InpMaxSpreadPips){
          Log(StringFormat("[REENTRY_STRICT_SKIP_SPREAD][%s]", B.name));
       }else{
-         if(A.activeTicket==0){
+         double diff = (ReArmB.dir>0)? MathAbs(Ask - ReArmB.target) : MathAbs(Bid - ReArmB.target);
+         bool hit   = (diff<=gap && ReArmB.prevDiff>gap);
+         ReArmB.prevDiff = diff;
+         if(hit){
             int tk = SendMarket(B, ReArmB.dir);
             if(tk>0){
                B.activeTicket=tk; B.lastDir=ReArmB.dir; B.entryPrice=MktPriceByDir(ReArmB.dir);
@@ -430,22 +420,6 @@ void TryReentryStrict(){
                int err=GetLastError();
                string tag=(err==ERR_REQUOTE||err==ERR_OFF_QUOTES)?"REENTRY_STRICT_REQUOTE":"REENTRY_STRICT_REJECT";
                Log(StringFormat("[%s][%s] err=%d", tag, B.name, err));
-            }
-         }else{
-            double diff = (ReArmB.dir>0)? MathAbs(Ask - ReArmB.target) : MathAbs(Bid - ReArmB.target);
-            bool hit = (diff<=gap && ReArmB.prevDiff>gap);
-            ReArmB.prevDiff = diff;
-            if(hit){
-               int tk = SendMarket(B, ReArmB.dir);
-               if(tk>0){
-                  B.activeTicket=tk; B.lastDir=ReArmB.dir; B.entryPrice=MktPriceByDir(ReArmB.dir);
-                  LogAlways(StringFormat("[REENTRY_STRICT_HIT][%s] ticket=%d", B.name, tk));
-                  ReArmB.armed=false;
-               }else{
-                  int err=GetLastError();
-                  string tag=(err==ERR_REQUOTE||err==ERR_OFF_QUOTES)?"REENTRY_STRICT_REQUOTE":"REENTRY_STRICT_REJECT";
-                  Log(StringFormat("[%s][%s] err=%d", tag, B.name, err));
-               }
             }
          }
       }


### PR DESCRIPTION
## Summary
- ensure re-entry orders are only sent after price hits target gap
- unify gap-check logic for both A and B systems

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a08b5c49448327b5665a8f79dd8d2d